### PR TITLE
Support for ParticipantBuiltInTopicData listener

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -38,6 +38,7 @@
       'target_name': 'node_opendds',
       'sources': [ 'src/node-opendds.cpp',
                    'src/NodeDRListener.cpp',
+                   'src/NodePBITListener.cpp',
                    'src/NodeQosConversion.cpp' ],
       'include_dirs': [ "<!(node -e \"require('nan')\")",
                       '$(ACE_ROOT)', '$(TAO_ROOT)', '$(DDS_ROOT)' ],

--- a/src/NodePBITListener.cpp
+++ b/src/NodePBITListener.cpp
@@ -1,0 +1,133 @@
+#include "NodePBITListener.h"
+
+#include <dds/DCPS/Service_Participant.h>
+#include <dds/DCPS/Registered_Data_Types.h>
+#include <dds/DCPS/BuiltInTopicUtils.h>
+
+#include <nan.h>
+#include <stdexcept>
+
+namespace NodeOpenDDS {
+using namespace v8;
+
+Local<Object> copytoV8(const DDS::Time_t& src)
+{
+  Local<Object> stru = Nan::New<Object>();
+  stru->Set(Nan::New<String>("sec").ToLocalChecked(), Nan::New(src.sec));
+  stru->Set(Nan::New<String>("nanosec").ToLocalChecked(),
+            Nan::New(src.nanosec));
+  return stru;
+}
+
+Local<Object> copytoV8(const DDS::SampleInfo& src)
+{
+  Local<Object> stru = Nan::New<Object>();
+#define INT(X) stru->Set(Nan::New<String>(#X).ToLocalChecked(), Nan::New(src.X))
+  INT(sample_state);
+  INT(view_state);
+  INT(instance_state);
+  stru->Set(Nan::New<String>("source_timestamp").ToLocalChecked(),
+            copytoV8(src.source_timestamp));
+  INT(instance_handle);
+  INT(publication_handle);
+  INT(disposed_generation_count);
+  INT(no_writers_generation_count);
+  INT(sample_rank);
+  INT(generation_rank);
+  INT(absolute_generation_rank);
+#undef INT
+  stru->Set(Nan::New<String>("valid_data").ToLocalChecked(),
+            Nan::New(src.valid_data));
+  return stru;
+}
+
+Local<Object> toV8(const DDS::ParticipantBuiltinTopicData& src)
+{
+  ACE_UNUSED_ARG(src);
+  Local<Object> stru = Nan::New<Object>();
+
+  std::string str;
+  for (CORBA::ULong i = 0; i < src.user_data.value.length(); ++i) {
+    str += src.user_data.value[i];
+  }
+  stru->Set(Nan::New<v8::String>("user_data").ToLocalChecked(), Nan::New(str).ToLocalChecked());
+  
+  const v8::Local<v8::Array> tgt(Nan::New<v8::Array>(3));
+  for (CORBA::Long i = 0; i < 3; ++i) {
+    tgt->Set(Nan::New(i), Nan::New(src.key.value[i]));
+  }
+  stru->Set(Nan::New<v8::String>("key").ToLocalChecked(), tgt);
+
+  return stru;
+}
+
+NodePBITListener::NodePBITListener(const Local<Function>& callback,
+                                  const DDS::ParticipantBuiltinTopicDataSeq part_data,
+                                  const DDS::SampleInfoSeq infos,
+                                  const DDS::DataReader_var& dr)
+  : callback_(callback)
+  , part_data_(part_data)
+  , infos_(infos)
+  , dr_(dr)
+  , async_uv_pbit_(this)
+{
+  uv_async_init(uv_default_loop(), &async_uv_pbit_, async_cb);
+}
+
+NodePBITListener::~NodePBITListener()
+{
+}
+
+void NodePBITListener::async_cb(uv_async_t* async_uv)
+{
+  static_cast<AsyncUvN*>(async_uv)->outer_->async();
+}
+
+void NodePBITListener::close_cb(uv_handle_t* handle_uv)
+{
+  static_cast<AsyncUvN*>((uv_async_t*)handle_uv)->outer_->_remove_ref();
+}
+
+void NodePBITListener::shutdown()
+{
+  _add_ref();
+  uv_close((uv_handle_t*)&async_uv_pbit_, close_cb);
+}
+
+void NodePBITListener::on_data_available(DDS::DataReader* dr)
+{
+
+  DDS::ParticipantBuiltinTopicDataDataReader_var part_dr =
+        DDS::ParticipantBuiltinTopicDataDataReader::_narrow(dr);
+  
+  part_dr->take(part_data_, infos_, 1, DDS::NOT_READ_SAMPLE_STATE, DDS::ANY_VIEW_STATE,
+            DDS::ANY_INSTANCE_STATE);
+  
+  uv_async_send(&async_uv_pbit_);
+}
+
+void NodePBITListener::async() // called from libuv event loop
+{
+  Nan::HandleScope scope;
+  
+  try {
+    const v8::Local<v8::Object> stru = Nan::New<v8::Object>();
+    
+    Local<Value> argv[] = { copytoV8(infos_[0]), toV8(part_data_[0]) };
+
+    Local<Function> callback = Nan::New(callback_);
+    Nan::Callback cb(callback);
+    cb.Call(sizeof(argv) / sizeof(argv[0]), argv);
+  } catch (...) {
+  }
+}
+
+void NodePBITListener::reserve(CORBA::ULong)
+{
+}
+
+void NodePBITListener::push_back(const DDS::SampleInfo& src, const void* sample)
+{
+}
+
+}

--- a/src/NodePBITListener.h
+++ b/src/NodePBITListener.h
@@ -1,0 +1,69 @@
+#ifndef OPENDDS_NODEPBITLISTENER_H
+#define OPENDDS_NODEPBITLISTENER_H
+
+#include <nan.h>
+
+#include <dds/DdsDcpsSubscriptionC.h>
+
+#include <dds/DCPS/Service_Participant.h>
+#include <dds/DCPS/Registered_Data_Types.h>
+#include <dds/DCPS/BuiltInTopicUtils.h>
+
+#include <dds/DCPS/V8TypeConverter.h>
+#include <dds/DCPS/LocalObject.h>
+#include <dds/DCPS/DataReaderImpl.h>
+
+namespace NodeOpenDDS {
+
+  class NodePBITListener
+    : public virtual OpenDDS::DCPS::LocalObject<DDS::DataReaderListener>
+    , private OpenDDS::DCPS::AbstractSamples {
+  public:
+    NodePBITListener(const v8::Local<v8::Function>& callback, 
+                    const DDS::ParticipantBuiltinTopicDataSeq part_data,
+                     const DDS::SampleInfoSeq infos, const DDS::DataReader_var& dr);
+    ~NodePBITListener();
+    void shutdown();
+
+  private:
+    static void async_cb(uv_async_t* async_uv);
+    static void close_cb(uv_handle_t* handle_uv);
+
+    typedef DDS::RequestedDeadlineMissedStatus RDMStatus;
+    void on_requested_deadline_missed(DDS::DataReader*, const RDMStatus&) {}
+    typedef DDS::RequestedIncompatibleQosStatus RIQStatus;
+    void on_requested_incompatible_qos(DDS::DataReader*, const RIQStatus&) {}
+    void on_sample_rejected(DDS::DataReader*,
+                            const DDS::SampleRejectedStatus&) {}
+    void on_liveliness_changed(DDS::DataReader*,
+                               const DDS::LivelinessChangedStatus&) {}
+    void on_subscription_matched(DDS::DataReader*,
+                                 const DDS::SubscriptionMatchedStatus&) {}
+    void on_sample_lost(DDS::DataReader*, const DDS::SampleLostStatus&) {}
+
+    void on_data_available(DDS::DataReader*);
+
+    void async(); // called from libuv event loop
+
+    Nan::Persistent<v8::Function> callback_;
+    const DDS::DataReader_var& dr_;
+
+    DDS::ParticipantBuiltinTopicDataSeq part_data_;
+    DDS::SampleInfoSeq infos_;
+
+    struct AsyncUvN : uv_async_t {
+      explicit AsyncUvN(NodePBITListener* outer) : outer_(outer) {}
+      NodePBITListener* outer_;
+    } async_uv_pbit_;
+
+    NodePBITListener(const NodePBITListener&);
+    NodePBITListener& operator=(const NodePBITListener&);
+
+   void reserve(CORBA::ULong);
+   void push_back(const DDS::SampleInfo& src, const void* sample);
+
+  };
+
+}
+
+#endif

--- a/src/node-opendds.cpp
+++ b/src/node-opendds.cpp
@@ -1,4 +1,5 @@
 #include "NodeDRListener.h"
+#include "NodePBITListener.h"
 #include "NodeQosConversion.h"
 
 #include <nan.h>
@@ -18,6 +19,7 @@
 using namespace v8;
 using OpenDDS::DCPS::Data_Types_Register;
 using NodeOpenDDS::NodeDRListener;
+using NodeOpenDDS::NodePBITListener;
 using NodeOpenDDS::convertQos;
 
 namespace {

--- a/test/test.js
+++ b/test/test.js
@@ -73,6 +73,11 @@ try {
       console.log("Error in callback: " + e);
     }
   });
+
+  participant.subscribe_participant_topic(function(info, participant) {
+    log('Received Participant', participant);
+    log('Received info', info);
+  });
 } catch (e) {
   console.log(e);
 }

--- a/test/test.js
+++ b/test/test.js
@@ -68,6 +68,7 @@ try {
       log('Sample Info', sinfo);
       if (sinfo.valid_data && sample.id === last_sample_id) {
         participant.unsubscribe(reader);
+        participant.unsubscribe_participant_topic();
       }
     } catch (e) {
       console.log("Error in callback: " + e);


### PR DESCRIPTION
DataListener implementation is done for ParticipantBuiltInTopic.
BuiltInTopic data parser is implemented, which generates UserDataQos and BuiltInTopicKey.
JS callback function is invoked on new participant.