### PR TITLE
Fix shutdown problems on the current OpenDDS master

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "opendds",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/NodeDRListener.cpp
+++ b/src/NodeDRListener.cpp
@@ -37,12 +37,15 @@ Local<Object> copyToV8(const DDS::SampleInfo& src)
   return stru;
 }
 
-NodeDRListener::NodeDRListener(const Local<Function>& callback,
+NodeDRListener::NodeDRListener(DDS::DomainParticipant* dp,
+                               const Local<Function>& callback,
                                const OpenDDS::DCPS::V8TypeConverter& conv)
-  : callback_(callback)
+  : dp_(dp)
+  , callback_(callback)
   , conv_(conv)
   , async_uv_(this)
   , unsubscribing_(false)
+  , receiving_samples_(false)
 {
   uv_async_init(uv_default_loop(), &async_uv_, async_cb);
 }
@@ -61,12 +64,6 @@ void NodeDRListener::close_cb(uv_handle_t* handle_uv)
   static_cast<AsyncUv*>((uv_async_t*)handle_uv)->outer_->_remove_ref();
 }
 
-void NodeDRListener::shutdown()
-{
-  _add_ref();
-  uv_close((uv_handle_t*)&async_uv_, close_cb);
-}
-
 void NodeDRListener::on_data_available(DDS::DataReader*)
 {
   if (unsubscribing_) {
@@ -78,6 +75,8 @@ void NodeDRListener::on_data_available(DDS::DataReader*)
 
 void NodeDRListener::async() // called from libuv event loop
 {
+  receiving_samples_ = true;
+
   Nan::HandleScope scope;
   Local<v8::Object> js_dr = Nan::New(js_dr_);
   void* const dr_obj = Nan::GetInternalFieldPointer(js_dr, 0);
@@ -90,6 +89,11 @@ void NodeDRListener::async() // called from libuv event loop
     dri->take(*this, DDS::NOT_READ_SAMPLE_STATE, DDS::ANY_VIEW_STATE,
               DDS::ANY_INSTANCE_STATE);
   } catch (...) {
+  }
+
+  receiving_samples_ = false;
+  if (unsubscribing_) {
+    Nan::AsyncQueueWorker(new UnsubscribeWorker(this));
   }
 }
 
@@ -115,15 +119,69 @@ void NodeDRListener::push_back(const DDS::SampleInfo& src, const void* sample)
   Local<Function> callback = Nan::New(callback_);
   Nan::Callback cb(callback);
   cb.Call(sizeof(argv) / sizeof(argv[0]), argv);
+}
 
-  // check for the case of unsubscribe inside the callback
-  if (!Nan::GetInternalFieldPointer(argv[0].As<v8::Object>(), 0)) {
-    throw std::runtime_error("invalid Javascript Data Reader callback object");
+void NodeDRListener::unsubscribe() {
+  if (receiving_samples_) {
+    // Inform the Listener to skip any remaining takes and use
+    // UnsubscibeWorker to unsubscribe at the next opportunity.
+    unsubscribing_ = true;
+  } else { // Unsubscribe Now
+    unsubscribe_now();
   }
 }
 
-void NodeDRListener::unsubscribing() {
-  unsubscribing_ = true;
+void NodeDRListener::unsubscribe_now() {
+  Local<v8::Object> dr_js = Nan::New(js_dr_);
+  void* const dr_obj = Nan::GetInternalFieldPointer(dr_js, 0);
+  DDS::DataReader_var dr = static_cast<DDS::DataReader*>(dr_obj);
+  Nan::SetInternalFieldPointer(dr_js, 0, 0);
+
+  _add_ref();
+  uv_close((uv_handle_t*)&async_uv_, close_cb);
+
+  const DDS::Subscriber_var sub = dr->get_subscriber();
+  const DDS::TopicDescription_var td = dr->get_topicdescription();
+  dr = 0;
+  sub->delete_contained_entities();
+  dp_->delete_subscriber(sub);
+
+  const DDS::ContentFilteredTopic_var cft =
+    DDS::ContentFilteredTopic::_narrow(td);
+  if (cft) {
+    const DDS::Topic_var topic = cft->get_related_topic();
+    dp_->delete_contentfilteredtopic(cft);
+    dp_->delete_topic(topic);
+  } else {
+    const DDS::Topic_var topic = DDS::Topic::_narrow(td);
+    dp_->delete_topic(topic);
+  }
 }
+
+UnsubscribeWorker::UnsubscribeWorker(NodeDRListener* ndrl) : AsyncWorker(NULL)
+{
+  ndrl_ = ndrl;
+}
+
+UnsubscribeWorker::~UnsubscribeWorker()
+{
+}
+
+void UnsubscribeWorker::Execute()
+{
+}
+
+void UnsubscribeWorker::Destroy()
+{
+}
+
+void UnsubscribeWorker::HandleOKCallback()
+{
+  ndrl_->unsubscribe_now();
+}
+void UnsubscribeWorker::HandleErrorCallback()
+{
+}
+
 
 }

--- a/src/NodeDRListener.h
+++ b/src/NodeDRListener.h
@@ -19,6 +19,7 @@ namespace NodeOpenDDS {
                    const OpenDDS::DCPS::V8TypeConverter& conv);
     ~NodeDRListener();
     void set_javascript_datareader(const v8::Local<v8::Object>& js_dr);
+    void unsubscribing();
     void shutdown();
 
   private:
@@ -53,8 +54,10 @@ namespace NodeOpenDDS {
     NodeDRListener(const NodeDRListener&);
     NodeDRListener& operator=(const NodeDRListener&);
 
-   void reserve(CORBA::ULong);
-   void push_back(const DDS::SampleInfo& src, const void* sample);
+    void reserve(CORBA::ULong);
+    void push_back(const DDS::SampleInfo& src, const void* sample);
+
+    bool unsubscribing_;
 
   };
 

--- a/src/node-opendds.cpp
+++ b/src/node-opendds.cpp
@@ -47,7 +47,6 @@ namespace {
   void delete_participant(const Nan::FunctionCallbackInfo<Value>& fci);
   void subscribe(const Nan::FunctionCallbackInfo<Value>& fci);
   void unsubscribe(const Nan::FunctionCallbackInfo<Value>& fci);
-  void unsubscribe_now(const Nan::FunctionCallbackInfo<Value>& fci);
 
   void initialize(const Nan::FunctionCallbackInfo<Value>& fci)
   {
@@ -101,7 +100,6 @@ namespace {
     ot->SetInternalFieldCount(1);
     Nan::SetMethod(ot, "subscribe", subscribe);
     Nan::SetMethod(ot, "unsubscribe", unsubscribe);
-    Nan::SetMethod(ot, "unsubscribe_now", unsubscribe_now);
     const Local<Object> obj = ot->NewInstance();
     Nan::SetInternalFieldPointer(obj, 0, dp._retn());
     fci.GetReturnValue().Set(obj);
@@ -227,7 +225,7 @@ namespace {
     }
 
     Local<Value> cb = fci[fci.Length() - 1];
-    NodeDRListener* const ndrl = new NodeDRListener(cb.As<Function>(), *tc);
+    NodeDRListener* const ndrl = new NodeDRListener(dp, cb.As<Function>(), *tc);
     const DDS::DataReaderListener_var listen(ndrl);
 
     DDS::DataReaderQos dr_qos;
@@ -268,56 +266,7 @@ namespace {
     DDS::DataReader* dr = static_cast<DDS::DataReader*>(dr_obj);
     NodeDRListener* const ndrl = dynamic_cast<NodeDRListener*>(dr->get_listener());
 
-    // Inform the Listener to skip any remaining takes
-    ndrl->unsubscribing();
-
-    // Schedule a call to unsubscribe_now right after this event
-    Nan::HandleScope scope;
-    Local<Object> globals = fci.GetIsolate()->GetCurrentContext()->Global();
-    globals->Set(V8STR("_cb_obj"), fci.This());
-    globals->Set(V8STR("_cb_arg"), fci[0]);
-    RUN(
-      "setImmediate(function(){_cb_obj.unsubscribe_now(_cb_arg);});"
-    );
-
-    fci.GetReturnValue().SetUndefined();
-  }
-
-  void unsubscribe_now(const Nan::FunctionCallbackInfo<Value>& fci)
-  {
-    if (fci.Length() < 1 || !fci[0]->IsObject()) {
-      Nan::ThrowTypeError("1 argument required");
-      fci.GetReturnValue().SetUndefined();
-      return;
-    }
-    void* const internal = Nan::GetInternalFieldPointer(fci.This(), 0);
-    DDS::DomainParticipant* const dp =
-      static_cast<DDS::DomainParticipant*>(internal);
-
-    const Local<Object> dr_js = fci[0]->ToObject();
-    void* const dr_obj = Nan::GetInternalFieldPointer(dr_js, 0);
-    DDS::DataReader_var dr = static_cast<DDS::DataReader*>(dr_obj);
-    Nan::SetInternalFieldPointer(dr_js, 0, 0);
-    const DDS::DataReaderListener_var drl = dr->get_listener();
-    NodeDRListener* const ndrl = dynamic_cast<NodeDRListener*>(drl.in());
-    ndrl->shutdown();
-
-    const DDS::Subscriber_var sub = dr->get_subscriber();
-    const DDS::TopicDescription_var td = dr->get_topicdescription();
-    dr = 0;
-    sub->delete_contained_entities();
-    dp->delete_subscriber(sub);
-
-    const DDS::ContentFilteredTopic_var cft =
-      DDS::ContentFilteredTopic::_narrow(td);
-    if (cft) {
-      const DDS::Topic_var topic = cft->get_related_topic();
-      dp->delete_contentfilteredtopic(cft);
-      dp->delete_topic(topic);
-    } else {
-      const DDS::Topic_var topic = DDS::Topic::_narrow(td);
-      dp->delete_topic(topic);
-    }
+    ndrl->unsubscribe();
 
     fci.GetReturnValue().SetUndefined();
   }


### PR DESCRIPTION
Fixed segfault on shutdown caused by WeakRcHandle refactor in OpenDDS.
This fix consists of delaying reader unsubscribe called from callback
until the next Node event, when current sample reading is done.