### PR TITLE
Update tests and coverage to accomodate recent changes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,7 +74,7 @@ jobs:
         if: ${{ matrix.m.dds_security == 1 && matrix.m.os == 'macos-latest' }}
       - name: 'Configure & Build OpenDDS'
         run: |-
-          if [ ${{ matrix.node_version }} >= 16 ]; then
+          if [ ${{ matrix.node_version }} == 16 ]; then
             CONFIG_OPTIONS+=" --std=c++14";
           else
             CONFIG_OPTIONS+=" --std=c++11";

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,9 +7,9 @@ on:
   push:
     branches:
       - master
-      - MigrateToGithubActions
   schedule:
     - cron: '10 0 * * 0'
+
 jobs:
   build:
     strategy:
@@ -17,13 +17,17 @@ jobs:
       matrix:
         node_version:
           - 10
+          - 12
+          - 14
+          - 16
         opendds_branch:
-          # - master
+          - master
           # - latest-release
           - branch-DDS-3.14
         m:
           - {os: ubuntu-latest, dds_security: 1}
           - {os: macos-latest, dds_security: 0}
+
     runs-on: ${{ matrix.m.os }}
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,6 +74,11 @@ jobs:
         if: ${{ matrix.m.dds_security == 1 && matrix.m.os == 'macos-latest' }}
       - name: 'Configure & Build OpenDDS'
         run: |-
+          if [ ${{ matrix.node_version >= 16 ]; then
+            CONFIG_OPTIONS+=" --std=c++14";
+          else
+            CONFIG_OPTIONS+=" --std=c++11";
+          fi
           if [ ${{ matrix.m.dds_security }} == 1 ]; then
             CONFIG_OPTIONS+=" --security";
             BUILD_TARGETS+="OpenDDS_Security";

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,9 +23,11 @@ jobs:
         opendds_branch:
           - master
           # - latest-release
-          - branch-DDS-3.14
+          # - branch-DDS-3.14
         m:
           - {os: ubuntu-latest, dds_security: 1}
+          - {os: ubuntu-latest, dds_security: 0}
+          - {os: macos-latest, dds_security: 1}
           - {os: macos-latest, dds_security: 0}
 
     runs-on: ${{ matrix.m.os }}
@@ -61,11 +63,15 @@ jobs:
           ref: ${{ matrix.opendds_branch }}
           path: OpenDDS
           fetch-depth: 1
-      - name: 'Install ssl and xerces'
+      - name: 'Install ssl and xerces (ubuntu)'
         run: |-
           sudo apt-get update
           sudo apt-get -y install libssl-dev libxerces-c-dev
-        if: ${{ matrix.m.dds_security == 1 }}
+        if: ${{ matrix.m.dds_security == 1 && matrix.m.os == 'ubuntu-latest' }}
+      - name: 'Install xerces (macos)'
+        run: |
+          brew install xerces-c
+        if: ${{ matrix.m.dds_security == 1 && matrix.m.os == 'macos-latest' }}
       - name: 'Configure & Build OpenDDS'
         run: |-
           if [ ${{ matrix.m.dds_security }} == 1 ]; then
@@ -74,7 +80,7 @@ jobs:
           fi
           echo "dds_security=${{ matrix.m.dds_security }}; CONFIG_OPTIONS=$CONFIG_OPTIONS; BUILD_TARGETS=$BUILD_TARGETS"
           cd OpenDDS
-          ./configure --no-tests --std=c++11 $CONFIG_OPTIONS
+          ./configure --no-tests $CONFIG_OPTIONS
           cd ..
           make -C OpenDDS -sj6 DCPSInfoRepo_Main OpenDDS_Rtps_Udp $BUILD_TARGETS
       - name: 'Install node, Build, Test'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,8 +75,11 @@ jobs:
       - name: 'Configure & Build OpenDDS'
         run: |-
           if [ ${{ matrix.m.dds_security }} == 1 ]; then
-            CONFIG_OPTIONS+="--security";
+            CONFIG_OPTIONS+=" --security";
             BUILD_TARGETS+="OpenDDS_Security";
+            if [ ${{ matrix.m.os }} == 'macos-latest'}} ]; then
+              CONFIG_OPTIONS+=" --xerces3=/usr/local/Cellar/xerces-c/3.2.3 --openssl=/usr/local/opt/openssl@1.1"
+            fi
           fi
           echo "dds_security=${{ matrix.m.dds_security }}; CONFIG_OPTIONS=$CONFIG_OPTIONS; BUILD_TARGETS=$BUILD_TARGETS"
           cd OpenDDS

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,7 +74,7 @@ jobs:
         if: ${{ matrix.m.dds_security == 1 && matrix.m.os == 'macos-latest' }}
       - name: 'Configure & Build OpenDDS'
         run: |-
-          if [ ${{ matrix.node_version >= 16 ]; then
+          if [ ${{ matrix.node_version }} >= 16 ]; then
             CONFIG_OPTIONS+=" --std=c++14";
           else
             CONFIG_OPTIONS+=" --std=c++11";

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,7 +77,7 @@ jobs:
           if [ ${{ matrix.m.dds_security }} == 1 ]; then
             CONFIG_OPTIONS+=" --security";
             BUILD_TARGETS+="OpenDDS_Security";
-            if [ ${{ matrix.m.os }} == 'macos-latest'}} ]; then
+            if [ '${{ matrix.m.os }}' == 'macos-latest' ]; then
               CONFIG_OPTIONS+=" --xerces3=/usr/local/Cellar/xerces-c/3.2.3 --openssl=/usr/local/opt/openssl@1.1"
             fi
           fi

--- a/src/NodeDRListener.cpp
+++ b/src/NodeDRListener.cpp
@@ -9,8 +9,8 @@ using namespace v8;
 Local<Object> copyToV8(const DDS::Time_t& src)
 {
   Local<Object> stru = Nan::New<Object>();
-  stru->Set(Nan::New<String>("sec").ToLocalChecked(), Nan::New(src.sec));
-  stru->Set(Nan::New<String>("nanosec").ToLocalChecked(),
+  Nan::Set(stru, Nan::New<String>("sec").ToLocalChecked(), Nan::New(src.sec));
+  Nan::Set(stru, Nan::New<String>("nanosec").ToLocalChecked(),
             Nan::New(src.nanosec));
   return stru;
 }
@@ -18,11 +18,11 @@ Local<Object> copyToV8(const DDS::Time_t& src)
 Local<Object> copyToV8(const DDS::SampleInfo& src)
 {
   Local<Object> stru = Nan::New<Object>();
-#define INT(X) stru->Set(Nan::New<String>(#X).ToLocalChecked(), Nan::New(src.X))
+#define INT(X) Nan::Set(stru, Nan::New<String>(#X).ToLocalChecked(), Nan::New(src.X))
   INT(sample_state);
   INT(view_state);
   INT(instance_state);
-  stru->Set(Nan::New<String>("source_timestamp").ToLocalChecked(),
+  Nan::Set(stru, Nan::New<String>("source_timestamp").ToLocalChecked(),
             copyToV8(src.source_timestamp));
   INT(instance_handle);
   INT(publication_handle);
@@ -32,7 +32,7 @@ Local<Object> copyToV8(const DDS::SampleInfo& src)
   INT(generation_rank);
   INT(absolute_generation_rank);
 #undef INT
-  stru->Set(Nan::New<String>("valid_data").ToLocalChecked(),
+  Nan::Set(stru, Nan::New<String>("valid_data").ToLocalChecked(),
             Nan::New(src.valid_data));
   return stru;
 }
@@ -113,9 +113,11 @@ void NodeDRListener::push_back(const DDS::SampleInfo& src, const void* sample)
     return;
   }
 
-  Local<Value> argv[] = {Nan::New(js_dr_), Handle<Value>(copyToV8(src)),
-                         src.valid_data ? conv_.toV8(sample).As<Value>()
-                         : Nan::Undefined().As<Value>()};
+  Local<Value> argv[] = {
+    Nan::New(js_dr_),
+    copyToV8(src),
+    src.valid_data ? conv_.toV8(sample).As<Value>() : Nan::Undefined().As<Value>()
+  };
 
   Local<Function> callback = Nan::New(callback_);
   Nan::Callback cb(callback);

--- a/src/NodeQosConversion.cpp
+++ b/src/NodeQosConversion.cpp
@@ -10,40 +10,41 @@ namespace NodeOpenDDS {
 
 void convert(DDS::OctetSeq& seq, const Local<String>& js_str)
 {
-  seq.length(js_str->Utf8Length());
-  js_str->WriteUtf8(reinterpret_cast<char*>(seq.get_buffer()), seq.length());
+  const Nan::Utf8String value(js_str);
+  seq.length(value.length());
+  memcpy(seq.get_buffer(), *value, value.length());
 }
 
 void convertQos(DDS::DomainParticipantQos& qos,
                 const Local<Object>& qos_js)
 {
   const Local<String> user_data = Nan::New<String>("user_data").ToLocalChecked();
-  if (qos_js->Has(user_data)) {
-    convert(qos.user_data.value, qos_js->Get(user_data)->ToString());
+  if (Nan::Has(qos_js, user_data).ToChecked()) {
+    convert(qos.user_data.value, Nan::Get(qos_js, user_data).ToLocalChecked()->ToString(Nan::GetCurrentContext()).ToLocalChecked());
   }
   // entity_factory QoS is not supported since there is no enable() method
 
   // If it exists, get the PropertyQosPolicy that enables security features:
   const Local<String> prop_str = Nan::New<String>("property").ToLocalChecked();
-  if (qos_js->Has(prop_str) && qos_js->Get(prop_str)->IsObject()) {
-    const Local<Object> props_policy_js = qos_js->Get(prop_str)->ToObject(Nan::GetCurrentContext()).ToLocalChecked();
+  if (Nan::Has(qos_js, prop_str).ToChecked() && Nan::Get(qos_js, prop_str).ToLocalChecked()->IsObject()) {
+    const Local<Object> props_policy_js = Nan::Get(qos_js, prop_str).ToLocalChecked()->ToObject(Nan::GetCurrentContext()).ToLocalChecked();
     const Local<String> name_str = Nan::New<String>("name").ToLocalChecked(),
       value_str = Nan::New<String>("value").ToLocalChecked();
-    if (props_policy_js->Has(value_str) && props_policy_js->Get(value_str)->IsObject()) {
-      const Local<Object> props_array_js = props_policy_js->Get(value_str)->ToObject(Nan::GetCurrentContext()).ToLocalChecked();
+    if (Nan::Has(props_policy_js, value_str).ToChecked() && Nan::Get(props_policy_js, value_str).ToLocalChecked()->IsObject()) {
+      const Local<Object> props_array_js = Nan::Get(props_policy_js, value_str).ToLocalChecked()->ToObject(Nan::GetCurrentContext()).ToLocalChecked();
       const Local<String> len_str = Nan::New<String>("length").ToLocalChecked();
 
       // Iterate over the properties in the policy and add them to the native QoS
-      const Nan::Maybe<uint32_t> props_array_len = Nan::To<uint32_t>(props_array_js->Get(len_str));
+      const Nan::Maybe<uint32_t> props_array_len = Nan::To<uint32_t>(Nan::Get(props_array_js, len_str).ToLocalChecked());
       const uint32_t len = props_array_len.FromMaybe(0);
       qos.property.value.length(len);
       for (uint32_t i = 0; i < len; ++i) {
-        if (props_array_js->Get(i)->IsObject()) {
-          const Local<Object> property_js = props_array_js->Get(i)->ToObject(Nan::GetCurrentContext()).ToLocalChecked();
-          if (property_js->Has(name_str) && property_js->Has(value_str)) {
-            const Nan::Utf8String name(property_js->Get(name_str));
+        if (Nan::Get(props_array_js, i).ToLocalChecked()->IsObject()) {
+          const Local<Object> property_js = Nan::Get(props_array_js, i).ToLocalChecked()->ToObject(Nan::GetCurrentContext()).ToLocalChecked();
+          if (Nan::Has(property_js, name_str).ToChecked() && Nan::Has(property_js, value_str).ToChecked()) {
+            const Nan::Utf8String name(Nan::Get(property_js, name_str).ToLocalChecked());
             qos.property.value[i].name = *name;
-            const Nan::Utf8String value(property_js->Get(value_str));
+            const Nan::Utf8String value(Nan::Get(property_js, value_str).ToLocalChecked());
             qos.property.value[i].value = *value;
           } else {
             throw std::runtime_error(
@@ -61,8 +62,8 @@ void convertQos(DDS::PresentationQosPolicy& qos, const Local<Object>& qos_js)
     coher_str = Nan::New<String>("coherent_access").ToLocalChecked(),
     order_str = Nan::New<String>("ordered_access").ToLocalChecked();
 
-  if (qos_js->Has(scope_str)) {
-    const Nan::Utf8String scope(qos_js->Get(scope_str));
+  if (Nan::Has(qos_js, scope_str).ToChecked()) {
+    const Nan::Utf8String scope(Nan::Get(qos_js, scope_str).ToLocalChecked());
     if (0 == std::strcmp(*scope, "INSTANCE_PRESENTATION_QOS")) {
       qos.access_scope = DDS::INSTANCE_PRESENTATION_QOS;
     } else if (0 == std::strcmp(*scope, "TOPIC_PRESENTATION_QOS")) {
@@ -71,22 +72,22 @@ void convertQos(DDS::PresentationQosPolicy& qos, const Local<Object>& qos_js)
       qos.access_scope = DDS::GROUP_PRESENTATION_QOS;
     }
   }
-  if (qos_js->Has(coher_str)) {
-    qos.coherent_access = qos_js->Get(coher_str)->BooleanValue();
+  if (Nan::Has(qos_js, coher_str).ToChecked()) {
+    qos.coherent_access = Nan::To<bool>(Nan::Get(qos_js, coher_str).ToLocalChecked()).FromMaybe(false);
   }
-  if (qos_js->Has(order_str)) {
-    qos.ordered_access = qos_js->Get(order_str)->BooleanValue();
+  if (Nan::Has(qos_js, order_str).ToChecked()) {
+    qos.ordered_access = Nan::To<bool>(Nan::Get(qos_js, order_str).ToLocalChecked()).FromMaybe(false);
   }
 }
 
 void convertQos(DDS::PartitionQosPolicy& qos, const Local<Object>& qos_js)
 {
   const Local<String> len_str = Nan::New<String>("length").ToLocalChecked();
-  const Nan::Maybe<uint32_t> parti_len = Nan::To<uint32_t>(qos_js->Get(len_str));
+  const Nan::Maybe<uint32_t> parti_len = Nan::To<uint32_t>(Nan::Get(qos_js, len_str).ToLocalChecked());
   const uint32_t len = parti_len.FromMaybe(0);
   qos.name.length(len);
   for (uint32_t i = 0; i < len; ++i) {
-    const Nan::Utf8String elt(qos_js->Get(i));
+    const Nan::Utf8String elt(Nan::Get(qos_js, i).ToLocalChecked());
     qos.name[i] = *elt;
   }
 }
@@ -97,16 +98,16 @@ void convertQos(DDS::PublisherQos& qos, const Local<Object>& qos_js)
     parti_str = Nan::New<String>("partition").ToLocalChecked(),
     grpd_str = Nan::New<String>("group_data").ToLocalChecked();
 
-  if (qos_js->Has(pres_str) && qos_js->Get(pres_str)->IsObject()) {
-    convertQos(qos.presentation, qos_js->Get(pres_str)->ToObject(Nan::GetCurrentContext()).ToLocalChecked());
+  if (Nan::Has(qos_js, pres_str).ToChecked() && Nan::Get(qos_js, pres_str).ToLocalChecked()->IsObject()) {
+    convertQos(qos.presentation, Nan::Get(qos_js, pres_str).ToLocalChecked()->ToObject(Nan::GetCurrentContext()).ToLocalChecked());
   }
 
-  if (qos_js->Has(parti_str) && qos_js->Get(parti_str)->IsObject()) {
-    convertQos(qos.partition, qos_js->Get(parti_str)->ToObject(Nan::GetCurrentContext()).ToLocalChecked());
+  if (Nan::Has(qos_js, parti_str).ToChecked() && Nan::Get(qos_js, parti_str).ToLocalChecked()->IsObject()) {
+    convertQos(qos.partition, Nan::Get(qos_js, parti_str).ToLocalChecked()->ToObject(Nan::GetCurrentContext()).ToLocalChecked());
   }
 
-  if (qos_js->Has(grpd_str)) {
-    convert(qos.group_data.value, qos_js->Get(grpd_str)->ToString());
+  if (Nan::Has(qos_js, grpd_str).ToChecked()) {
+    convert(qos.group_data.value, Nan::Get(qos_js, grpd_str).ToLocalChecked()->ToString(Nan::GetCurrentContext()).ToLocalChecked());
   }
 }
 
@@ -116,16 +117,16 @@ void convertQos(DDS::SubscriberQos& qos, const Local<Object>& qos_js)
     parti_str = Nan::New<String>("partition").ToLocalChecked(),
     grpd_str = Nan::New<String>("group_data").ToLocalChecked();
 
-  if (qos_js->Has(pres_str) && qos_js->Get(pres_str)->IsObject()) {
-    convertQos(qos.presentation, qos_js->Get(pres_str)->ToObject(Nan::GetCurrentContext()).ToLocalChecked());
+  if (Nan::Has(qos_js, pres_str).ToChecked() && Nan::Get(qos_js, pres_str).ToLocalChecked()->IsObject()) {
+    convertQos(qos.presentation, Nan::Get(qos_js, pres_str).ToLocalChecked()->ToObject(Nan::GetCurrentContext()).ToLocalChecked());
   }
 
-  if (qos_js->Has(parti_str) && qos_js->Get(parti_str)->IsObject()) {
-    convertQos(qos.partition, qos_js->Get(parti_str)->ToObject(Nan::GetCurrentContext()).ToLocalChecked());
+  if (Nan::Has(qos_js, parti_str).ToChecked() && Nan::Get(qos_js, parti_str).ToLocalChecked()->IsObject()) {
+    convertQos(qos.partition, Nan::Get(qos_js, parti_str).ToLocalChecked()->ToObject(Nan::GetCurrentContext()).ToLocalChecked());
   }
 
-  if (qos_js->Has(grpd_str)) {
-    convert(qos.group_data.value, qos_js->Get(grpd_str)->ToString());
+  if (Nan::Has(qos_js, grpd_str).ToChecked()) {
+    convert(qos.group_data.value, Nan::Get(qos_js, grpd_str).ToLocalChecked()->ToString(Nan::GetCurrentContext()).ToLocalChecked());
   }
 }
 
@@ -134,11 +135,11 @@ void convert(DDS::Duration_t& dur, const Local<Object>& dur_js)
   const Local<String> sec_str = Nan::New<String>("sec").ToLocalChecked(),
     nanosec_str = Nan::New<String>("nanosec").ToLocalChecked();
 
-  if (dur_js->Has(sec_str) && dur_js->Get(sec_str)->IsInt32()) {
-    dur.sec = dur_js->Get(sec_str)->Int32Value(Nan::GetCurrentContext()).ToChecked();
+  if (Nan::Has(dur_js, sec_str).ToChecked()) {
+    dur.sec = Nan::To<int32_t>(Nan::Get(dur_js, sec_str).ToLocalChecked()).FromMaybe(0);
   }
-  if (dur_js->Has(nanosec_str) && dur_js->Get(nanosec_str)->IsUint32()) {
-    dur.nanosec = dur_js->Get(nanosec_str)->Uint32Value(Nan::GetCurrentContext()).ToChecked();
+  if (Nan::Has(dur_js, nanosec_str).ToChecked()) {
+    dur.nanosec = Nan::To<uint32_t>(Nan::Get(dur_js, nanosec_str).ToLocalChecked()).FromMaybe(0);
   }
 }
 
@@ -151,28 +152,28 @@ void convertQos(DDS::DurabilityServiceQosPolicy& qos, const Local<Object>& qos_j
     mi_str = Nan::New<String>("max_instances").ToLocalChecked(),
     mspi_str = Nan::New<String>("max_samples_per_instance").ToLocalChecked();
 
-  if (qos_js->Has(scd_str) && qos_js->Get(scd_str)->IsObject()) {
-    convert(qos.service_cleanup_delay, qos_js->Get(scd_str)->ToObject(Nan::GetCurrentContext()).ToLocalChecked());
+  if (Nan::Has(qos_js, scd_str).ToChecked() && Nan::Get(qos_js, scd_str).ToLocalChecked()->IsObject()) {
+    convert(qos.service_cleanup_delay, Nan::Get(qos_js, scd_str).ToLocalChecked()->ToObject(Nan::GetCurrentContext()).ToLocalChecked());
   }
-  if (qos_js->Has(hk_str)) {
-    const Nan::Utf8String dur(qos_js->Get(hk_str));
+  if (Nan::Has(qos_js, hk_str).ToChecked()) {
+    const Nan::Utf8String dur(Nan::Get(qos_js, hk_str).ToLocalChecked());
     if (0 == std::strcmp(*dur, "KEEP_LAST_HISTORY_QOS")) {
       qos.history_kind = DDS::KEEP_LAST_HISTORY_QOS;
     } else if (0 == std::strcmp(*dur, "KEEP_ALL_HISTORY_QOS")) {
       qos.history_kind = DDS::KEEP_ALL_HISTORY_QOS;
     }
   }
-  if (qos_js->Has(hd_str) && qos_js->Get(hd_str)->IsInt32()) {
-    qos.history_depth = qos_js->Get(hd_str)->Int32Value(Nan::GetCurrentContext()).ToChecked();
+  if (Nan::Has(qos_js, hd_str).ToChecked()) {
+    qos.history_depth = Nan::To<int32_t>(Nan::Get(qos_js, hd_str).ToLocalChecked()).FromMaybe(0); 
   }
-  if (qos_js->Has(ms_str) && qos_js->Get(ms_str)->IsInt32()) {
-    qos.max_samples = qos_js->Get(ms_str)->Int32Value(Nan::GetCurrentContext()).ToChecked();
+  if (Nan::Has(qos_js, ms_str).ToChecked()) {
+    qos.max_samples = Nan::To<int32_t>(Nan::Get(qos_js, ms_str).ToLocalChecked()).FromMaybe(0); 
   }
-  if (qos_js->Has(mi_str) && qos_js->Get(mi_str)->IsInt32()) {
-    qos.max_instances = qos_js->Get(mi_str)->Int32Value(Nan::GetCurrentContext()).ToChecked();
+  if (Nan::Has(qos_js, mi_str).ToChecked()) {
+    qos.max_instances = Nan::To<int32_t>(Nan::Get(qos_js, mi_str).ToLocalChecked()).FromMaybe(0); 
   }
-  if (qos_js->Has(mspi_str) && qos_js->Get(mspi_str)->IsInt32()) {
-    qos.max_samples_per_instance = qos_js->Get(mspi_str)->Int32Value(Nan::GetCurrentContext()).ToChecked();
+  if (Nan::Has(qos_js, mspi_str).ToChecked()) {
+    qos.max_samples_per_instance = Nan::To<int32_t>(Nan::Get(qos_js, mspi_str).ToLocalChecked()).FromMaybe(0); 
   }
 }
 
@@ -181,8 +182,8 @@ void convertQos(DDS::LivelinessQosPolicy& qos, const Local<Object>& qos_js)
   const Local<String> kind_str = Nan::New<String>("kind").ToLocalChecked(),
     lease_duration_str = Nan::New<String>("lease_duration").ToLocalChecked();
 
-  if (qos_js->Has(kind_str)) {
-    const Nan::Utf8String lv(qos_js->Get(kind_str));
+  if (Nan::Has(qos_js, kind_str).ToChecked()) {
+    const Nan::Utf8String lv(Nan::Get(qos_js, kind_str).ToLocalChecked());
     if (0 == std::strcmp(*lv, "AUTOMATIC_LIVELINESS_QOS")) {
       qos.kind = DDS::AUTOMATIC_LIVELINESS_QOS;
     } else if (0 == std::strcmp(*lv, "MANUAL_BY_PARTICIPANT_LIVELINESS_QOS")) {
@@ -191,8 +192,8 @@ void convertQos(DDS::LivelinessQosPolicy& qos, const Local<Object>& qos_js)
       qos.kind = DDS::MANUAL_BY_TOPIC_LIVELINESS_QOS;
     }
   }
-  if (qos_js->Has(lease_duration_str) && qos_js->Get(lease_duration_str)->IsObject()) {
-    convert(qos.lease_duration, qos_js->Get(lease_duration_str)->ToObject(Nan::GetCurrentContext()).ToLocalChecked());
+  if (Nan::Has(qos_js, lease_duration_str).ToChecked() && Nan::Get(qos_js, lease_duration_str).ToLocalChecked()->IsObject()) {
+    convert(qos.lease_duration, Nan::Get(qos_js, lease_duration_str).ToLocalChecked()->ToObject(Nan::GetCurrentContext()).ToLocalChecked());
   }
 }
 
@@ -201,16 +202,16 @@ void convertQos(DDS::ReliabilityQosPolicy& qos, const Local<Object>& qos_js)
   const Local<String> kind_str = Nan::New<String>("kind").ToLocalChecked(),
     mbt_str = Nan::New<String>("max_blocking_time").ToLocalChecked();
 
-  if (qos_js->Has(kind_str)) {
-    const Nan::Utf8String rl(qos_js->Get(kind_str));
+  if (Nan::Has(qos_js, kind_str).ToChecked()) {
+    const Nan::Utf8String rl(Nan::Get(qos_js, kind_str).ToLocalChecked());
     if (0 == std::strcmp(*rl, "BEST_EFFORT_RELIABILITY_QOS")) {
       qos.kind = DDS::BEST_EFFORT_RELIABILITY_QOS;
     } else if (0 == std::strcmp(*rl, "RELIABLE_RELIABILITY_QOS")) {
       qos.kind = DDS::RELIABLE_RELIABILITY_QOS;
     }
   }
-  if (qos_js->Has(mbt_str) && qos_js->Get(mbt_str)->IsObject()) {
-    convert(qos.max_blocking_time, qos_js->Get(mbt_str)->ToObject(Nan::GetCurrentContext()).ToLocalChecked());
+  if (Nan::Has(qos_js, mbt_str).ToChecked() && Nan::Get(qos_js, mbt_str).ToLocalChecked()->IsObject()) {
+    convert(qos.max_blocking_time, Nan::Get(qos_js, mbt_str).ToLocalChecked()->ToObject(Nan::GetCurrentContext()).ToLocalChecked());
   }
 }
 
@@ -219,16 +220,16 @@ void convertQos(DDS::HistoryQosPolicy& qos, const Local<Object>& qos_js)
   const Local<String> kind_str = Nan::New<String>("kind").ToLocalChecked(),
     depth_str = Nan::New<String>("depth").ToLocalChecked();
 
-  if (qos_js->Has(kind_str)) {
-    const Nan::Utf8String hk(qos_js->Get(kind_str));
+  if (Nan::Has(qos_js, kind_str).ToChecked()) {
+    const Nan::Utf8String hk(Nan::Get(qos_js, kind_str).ToLocalChecked());
     if (0 == std::strcmp(*hk, "KEEP_LAST_HISTORY_QOS")) {
       qos.kind = DDS::KEEP_LAST_HISTORY_QOS;
     } else if (0 == std::strcmp(*hk, "KEEP_ALL_HISTORY_QOS")) {
       qos.kind = DDS::KEEP_ALL_HISTORY_QOS;
     }
   }
-  if (qos_js->Has(depth_str) && qos_js->Get(depth_str)->IsInt32()) {
-    qos.depth = qos_js->Get(depth_str)->Int32Value(Nan::GetCurrentContext()).ToChecked();
+  if (Nan::Has(qos_js, depth_str).ToChecked()) {
+    qos.depth = Nan::To<int32_t>(Nan::Get(qos_js, depth_str).ToLocalChecked()).FromMaybe(0); 
   }
 }
 
@@ -238,15 +239,14 @@ void convertQos(DDS::ResourceLimitsQosPolicy& qos, const Local<Object>& qos_js)
     mi_str = Nan::New<String>("max_instances").ToLocalChecked(),
     mspi_str = Nan::New<String>("max_samples_per_instance").ToLocalChecked();
 
-  if (qos_js->Has(ms_str) && qos_js->Get(ms_str)->IsInt32()) {
-    qos.max_samples = qos_js->Get(ms_str)->Int32Value(Nan::GetCurrentContext()).ToChecked();
+  if (Nan::Has(qos_js, ms_str).ToChecked()) {
+    qos.max_samples = Nan::To<int32_t>(Nan::Get(qos_js, ms_str).ToLocalChecked()).FromMaybe(0); 
   }
-  if (qos_js->Has(mi_str) && qos_js->Get(mi_str)->IsInt32()) {
-    qos.max_instances = qos_js->Get(mi_str)->Int32Value(Nan::GetCurrentContext()).ToChecked();
+  if (Nan::Has(qos_js, mi_str).ToChecked()) {
+    qos.max_instances = Nan::To<int32_t>(Nan::Get(qos_js, mi_str).ToLocalChecked()).FromMaybe(0); 
   }
-  if (qos_js->Has(mspi_str) && qos_js->Get(mspi_str)->IsInt32()) {
-    qos.max_samples_per_instance =
-      qos_js->Get(mspi_str)->Int32Value(Nan::GetCurrentContext()).ToChecked();
+  if (Nan::Has(qos_js, mspi_str).ToChecked()) {
+    qos.max_samples_per_instance = Nan::To<int32_t>(Nan::Get(qos_js, mspi_str).ToLocalChecked()).FromMaybe(0); 
   }
 }
 
@@ -268,8 +268,8 @@ void convertQos(DDS::DataWriterQos& qos, const Local<Object>& dwqos_js)
     ostrength_str = Nan::New<String>("ownership_strength").ToLocalChecked(),
     wdlife_str = Nan::New<String>("writer_data_lifecycle").ToLocalChecked();
 
-  if (dwqos_js->Has(durab_str)) {
-    const Nan::Utf8String dur(dwqos_js->Get(durab_str));
+  if (Nan::Has(dwqos_js, durab_str).ToChecked()) {
+    const Nan::Utf8String dur(Nan::Get(dwqos_js, durab_str).ToLocalChecked());
     if (0 == std::strcmp(*dur, "VOLATILE_DURABILITY_QOS")) {
       qos.durability.kind = DDS::VOLATILE_DURABILITY_QOS;
     } else if (0 == std::strcmp(*dur, "TRANSIENT_LOCAL_DURABILITY_QOS")) {
@@ -281,28 +281,28 @@ void convertQos(DDS::DataWriterQos& qos, const Local<Object>& dwqos_js)
     }
   }
 
-  if (dwqos_js->Has(durabsvc_str) && dwqos_js->Get(durabsvc_str)->IsObject()) {
-    convertQos(qos.durability_service, dwqos_js->Get(durabsvc_str)->ToObject(Nan::GetCurrentContext()).ToLocalChecked());
+  if (Nan::Has(dwqos_js, durabsvc_str).ToChecked() && Nan::Get(dwqos_js, durabsvc_str).ToLocalChecked()->IsObject()) {
+    convertQos(qos.durability_service, Nan::Get(dwqos_js, durabsvc_str).ToLocalChecked()->ToObject(Nan::GetCurrentContext()).ToLocalChecked());
   }
 
-  if (dwqos_js->Has(deadln_str) && dwqos_js->Get(deadln_str)->IsObject()) {
-    convert(qos.deadline.period, dwqos_js->Get(deadln_str)->ToObject(Nan::GetCurrentContext()).ToLocalChecked());
+  if (Nan::Has(dwqos_js, deadln_str).ToChecked() && Nan::Get(dwqos_js, deadln_str).ToLocalChecked()->IsObject()) {
+    convert(qos.deadline.period, Nan::Get(dwqos_js, deadln_str).ToLocalChecked()->ToObject(Nan::GetCurrentContext()).ToLocalChecked());
   }
 
-  if (dwqos_js->Has(latbud_str) && dwqos_js->Get(latbud_str)->IsObject()) {
-    convert(qos.latency_budget.duration, dwqos_js->Get(latbud_str)->ToObject(Nan::GetCurrentContext()).ToLocalChecked());
+  if (Nan::Has(dwqos_js, latbud_str).ToChecked() && Nan::Get(dwqos_js, latbud_str).ToLocalChecked()->IsObject()) {
+    convert(qos.latency_budget.duration, Nan::Get(dwqos_js, latbud_str).ToLocalChecked()->ToObject(Nan::GetCurrentContext()).ToLocalChecked());
   }
 
-  if (dwqos_js->Has(liveli_str) && dwqos_js->Get(liveli_str)->IsObject()) {
-    convertQos(qos.liveliness, dwqos_js->Get(liveli_str)->ToObject(Nan::GetCurrentContext()).ToLocalChecked());
+  if (Nan::Has(dwqos_js, liveli_str).ToChecked() && Nan::Get(dwqos_js, liveli_str).ToLocalChecked()->IsObject()) {
+    convertQos(qos.liveliness, Nan::Get(dwqos_js, liveli_str).ToLocalChecked()->ToObject(Nan::GetCurrentContext()).ToLocalChecked());
   }
 
-  if (dwqos_js->Has(reliab_str) && dwqos_js->Get(reliab_str)->IsObject()) {
-    convertQos(qos.reliability, dwqos_js->Get(reliab_str)->ToObject(Nan::GetCurrentContext()).ToLocalChecked());
+  if (Nan::Has(dwqos_js, reliab_str).ToChecked() && Nan::Get(dwqos_js, reliab_str).ToLocalChecked()->IsObject()) {
+    convertQos(qos.reliability, Nan::Get(dwqos_js, reliab_str).ToLocalChecked()->ToObject(Nan::GetCurrentContext()).ToLocalChecked());
   }
 
-  if (dwqos_js->Has(destord_str)) {
-    const Nan::Utf8String ord(dwqos_js->Get(destord_str));
+  if (Nan::Has(dwqos_js, destord_str).ToChecked()) {
+    const Nan::Utf8String ord(Nan::Get(dwqos_js, destord_str).ToLocalChecked());
     if (0 == std::strcmp(*ord, "BY_RECEPTION_TIMESTAMP_DESTINATIONORDER_QOS")) {
       qos.destination_order.kind =
         DDS::BY_RECEPTION_TIMESTAMP_DESTINATIONORDER_QOS;
@@ -313,28 +313,28 @@ void convertQos(DDS::DataWriterQos& qos, const Local<Object>& dwqos_js)
     }
   }
 
-  if (dwqos_js->Has(history_str) && dwqos_js->Get(history_str)->IsObject()) {
-    convertQos(qos.history, dwqos_js->Get(history_str)->ToObject(Nan::GetCurrentContext()).ToLocalChecked());
+  if (Nan::Has(dwqos_js, history_str).ToChecked() && Nan::Get(dwqos_js, history_str).ToLocalChecked()->IsObject()) {
+    convertQos(qos.history, Nan::Get(dwqos_js, history_str).ToLocalChecked()->ToObject(Nan::GetCurrentContext()).ToLocalChecked());
   }
 
-  if (dwqos_js->Has(reslim_str) && dwqos_js->Get(reslim_str)->IsObject()) {
-    convertQos(qos.resource_limits, dwqos_js->Get(reslim_str)->ToObject(Nan::GetCurrentContext()).ToLocalChecked());
+  if (Nan::Has(dwqos_js, reslim_str).ToChecked() && Nan::Get(dwqos_js, reslim_str).ToLocalChecked()->IsObject()) {
+    convertQos(qos.resource_limits, Nan::Get(dwqos_js, reslim_str).ToLocalChecked()->ToObject(Nan::GetCurrentContext()).ToLocalChecked());
   }
 
-  if (dwqos_js->Has(tranpri_str) && dwqos_js->Get(tranpri_str)->IsInt32()) {
-    qos.transport_priority.value = dwqos_js->Get(tranpri_str)->Int32Value(Nan::GetCurrentContext()).ToChecked();
+  if (Nan::Has(dwqos_js, tranpri_str).ToChecked()) {
+    qos.transport_priority.value = Nan::To<int32_t>(Nan::Get(dwqos_js, tranpri_str).ToLocalChecked()).FromMaybe(0);
   }
 
-  if (dwqos_js->Has(lifespan_str) && dwqos_js->Get(lifespan_str)->IsObject()) {
-    convert(qos.lifespan.duration, dwqos_js->Get(lifespan_str)->ToObject(Nan::GetCurrentContext()).ToLocalChecked());
+  if (Nan::Has(dwqos_js, lifespan_str).ToChecked() && Nan::Get(dwqos_js, lifespan_str).ToLocalChecked()->IsObject()) {
+    convert(qos.lifespan.duration, Nan::Get(dwqos_js, lifespan_str).ToLocalChecked()->ToObject(Nan::GetCurrentContext()).ToLocalChecked());
   }
 
-  if (dwqos_js->Has(userdata_str) && dwqos_js->Get(userdata_str)->IsString()) {
-    convert(qos.user_data.value, dwqos_js->Get(userdata_str)->ToString(Nan::GetCurrentContext()).ToLocalChecked());
+  if (Nan::Has(dwqos_js, userdata_str).ToChecked() && Nan::Get(dwqos_js, userdata_str).ToLocalChecked()->IsString()) {
+    convert(qos.user_data.value, Nan::Get(dwqos_js, userdata_str).ToLocalChecked()->ToString(Nan::GetCurrentContext()).ToLocalChecked());
   }
 
-  if (dwqos_js->Has(ownership_str) && dwqos_js->Get(ownership_str)->IsString()) {
-    const Nan::Utf8String own(dwqos_js->Get(ownership_str));
+  if (Nan::Has(dwqos_js, ownership_str).ToChecked() && Nan::Get(dwqos_js, ownership_str).ToLocalChecked()->IsString()) {
+    const Nan::Utf8String own(Nan::Get(dwqos_js, ownership_str).ToLocalChecked());
     if (0 == std::strcmp(*own, "SHARED_OWNERSHIP_QOS")) {
       qos.ownership.kind = DDS::SHARED_OWNERSHIP_QOS;
     } else if (0 == std::strcmp(*own, "EXCLUSIVE_OWNERSHIP_QOS")) {
@@ -342,19 +342,19 @@ void convertQos(DDS::DataWriterQos& qos, const Local<Object>& dwqos_js)
     }
   }
 
-  if (dwqos_js->Has(ostrength_str) && dwqos_js->Get(ostrength_str)->IsObject()) {
-    const Local<Object> ostrength = dwqos_js->Get(ostrength_str)->ToObject(Nan::GetCurrentContext()).ToLocalChecked();
+  if (Nan::Has(dwqos_js, ostrength_str).ToChecked() && Nan::Get(dwqos_js, ostrength_str).ToLocalChecked()->IsObject()) {
+    const Local<Object> ostrength = Nan::Get(dwqos_js, ostrength_str).ToLocalChecked()->ToObject(Nan::GetCurrentContext()).ToLocalChecked();
     const Local<String> v_str = Nan::New<String>("value").ToLocalChecked();
-    if (ostrength->Has(v_str) && ostrength->Get(v_str)->IsInt32()) {
-      qos.ownership_strength.value = ostrength->Get(v_str)->Int32Value(Nan::GetCurrentContext()).ToChecked();
+    if (Nan::Has(ostrength, v_str).ToChecked()) {
+      qos.ownership_strength.value = Nan::To<int32_t>(Nan::Get(ostrength, v_str).ToLocalChecked()).FromMaybe(0);
     }
   }
 
-  if (dwqos_js->Has(wdlife_str) && dwqos_js->Get(wdlife_str)->IsObject()) {
-    const Local<Object> wdlife = dwqos_js->Get(wdlife_str)->ToObject(Nan::GetCurrentContext()).ToLocalChecked();
+  if (Nan::Has(dwqos_js, wdlife_str).ToChecked() && Nan::Get(dwqos_js, wdlife_str).ToLocalChecked()->IsObject()) {
+    const Local<Object> wdlife = Nan::Get(dwqos_js, wdlife_str).ToLocalChecked()->ToObject(Nan::GetCurrentContext()).ToLocalChecked();
     const Local<String> adui_str = Nan::New<String>("autodispose_unregistered_instances").ToLocalChecked();
-    if (wdlife->Has(adui_str) && wdlife->Get(adui_str)->IsBoolean()) {
-      qos.writer_data_lifecycle.autodispose_unregistered_instances = wdlife->Get(adui_str)->BooleanValue(Nan::GetCurrentContext()).ToChecked();
+    if (Nan::Has(wdlife, adui_str).ToChecked()) {
+      qos.writer_data_lifecycle.autodispose_unregistered_instances = Nan::To<bool>(Nan::Get(wdlife, adui_str).ToLocalChecked()).FromMaybe(false);
     }
   }
 }
@@ -374,8 +374,8 @@ void convertQos(DDS::DataReaderQos& qos, const Local<Object>& drqos_js)
     tbfilter_str = Nan::New<String>("time_based_filter").ToLocalChecked(),
     rdlife_str = Nan::New<String>("reader_data_lifecycle").ToLocalChecked();
 
-  if (drqos_js->Has(durab_str) && drqos_js->Get(durab_str)->IsString()) {
-    const Nan::Utf8String dur(drqos_js->Get(durab_str));
+  if (Nan::Has(drqos_js, durab_str).ToChecked() && Nan::Get(drqos_js, durab_str).ToLocalChecked()->IsString()) {
+    const Nan::Utf8String dur(Nan::Get(drqos_js, durab_str).ToLocalChecked());
     if (0 == std::strcmp(*dur, "VOLATILE_DURABILITY_QOS")) {
       qos.durability.kind = DDS::VOLATILE_DURABILITY_QOS;
     } else if (0 == std::strcmp(*dur, "TRANSIENT_LOCAL_DURABILITY_QOS")) {
@@ -387,24 +387,24 @@ void convertQos(DDS::DataReaderQos& qos, const Local<Object>& drqos_js)
     }
   }
 
-  if (drqos_js->Has(deadln_str) && drqos_js->Get(deadln_str)->IsObject()) {
-    convert(qos.deadline.period, drqos_js->Get(deadln_str)->ToObject(Nan::GetCurrentContext()).ToLocalChecked());
+  if (Nan::Has(drqos_js, deadln_str).ToChecked() && Nan::Get(drqos_js, deadln_str).ToLocalChecked()->IsObject()) {
+    convert(qos.deadline.period, Nan::Get(drqos_js, deadln_str).ToLocalChecked()->ToObject(Nan::GetCurrentContext()).ToLocalChecked());
   }
 
-  if (drqos_js->Has(latbud_str) && drqos_js->Get(latbud_str)->IsObject()) {
-    convert(qos.latency_budget.duration, drqos_js->Get(latbud_str)->ToObject(Nan::GetCurrentContext()).ToLocalChecked());
+  if (Nan::Has(drqos_js, latbud_str).ToChecked() && Nan::Get(drqos_js, latbud_str).ToLocalChecked()->IsObject()) {
+    convert(qos.latency_budget.duration, Nan::Get(drqos_js, latbud_str).ToLocalChecked()->ToObject(Nan::GetCurrentContext()).ToLocalChecked());
   }
 
-  if (drqos_js->Has(liveli_str) && drqos_js->Get(liveli_str)->IsObject()) {
-    convertQos(qos.liveliness, drqos_js->Get(liveli_str)->ToObject(Nan::GetCurrentContext()).ToLocalChecked());
+  if (Nan::Has(drqos_js, liveli_str).ToChecked() && Nan::Get(drqos_js, liveli_str).ToLocalChecked()->IsObject()) {
+    convertQos(qos.liveliness, Nan::Get(drqos_js, liveli_str).ToLocalChecked()->ToObject(Nan::GetCurrentContext()).ToLocalChecked());
   }
 
-  if (drqos_js->Has(reliab_str) && drqos_js->Get(reliab_str)->IsObject()) {
-    convertQos(qos.reliability, drqos_js->Get(reliab_str)->ToObject(Nan::GetCurrentContext()).ToLocalChecked());
+  if (Nan::Has(drqos_js, reliab_str).ToChecked() && Nan::Get(drqos_js, reliab_str).ToLocalChecked()->IsObject()) {
+    convertQos(qos.reliability, Nan::Get(drqos_js, reliab_str).ToLocalChecked()->ToObject(Nan::GetCurrentContext()).ToLocalChecked());
   }
 
-  if (drqos_js->Has(destord_str)) {
-    const Nan::Utf8String ord(drqos_js->Get(destord_str));
+  if (Nan::Has(drqos_js, destord_str).ToChecked()) {
+    const Nan::Utf8String ord(Nan::Get(drqos_js, destord_str).ToLocalChecked());
     if (0 == std::strcmp(*ord, "BY_RECEPTION_TIMESTAMP_DESTINATIONORDER_QOS")) {
       qos.destination_order.kind =
         DDS::BY_RECEPTION_TIMESTAMP_DESTINATIONORDER_QOS;
@@ -415,20 +415,20 @@ void convertQos(DDS::DataReaderQos& qos, const Local<Object>& drqos_js)
     }
   }
 
-  if (drqos_js->Has(history_str) && drqos_js->Get(history_str)->IsObject()) {
-    convertQos(qos.history, drqos_js->Get(history_str)->ToObject(Nan::GetCurrentContext()).ToLocalChecked());
+  if (Nan::Has(drqos_js, history_str).ToChecked() && Nan::Get(drqos_js, history_str).ToLocalChecked()->IsObject()) {
+    convertQos(qos.history, Nan::Get(drqos_js, history_str).ToLocalChecked()->ToObject(Nan::GetCurrentContext()).ToLocalChecked());
   }
 
-  if (drqos_js->Has(reslim_str) && drqos_js->Get(reslim_str)->IsObject()) {
-    convertQos(qos.resource_limits, drqos_js->Get(reslim_str)->ToObject(Nan::GetCurrentContext()).ToLocalChecked());
+  if (Nan::Has(drqos_js, reslim_str).ToChecked() && Nan::Get(drqos_js, reslim_str).ToLocalChecked()->IsObject()) {
+    convertQos(qos.resource_limits, Nan::Get(drqos_js, reslim_str).ToLocalChecked()->ToObject(Nan::GetCurrentContext()).ToLocalChecked());
   }
 
-  if (drqos_js->Has(userdata_str)) {
-    convert(qos.user_data.value, drqos_js->Get(userdata_str)->ToString());
+  if (Nan::Has(drqos_js, userdata_str).ToChecked()) {
+    convert(qos.user_data.value, Nan::Get(drqos_js, userdata_str).ToLocalChecked()->ToString(Nan::GetCurrentContext()).ToLocalChecked());
   }
 
-  if (drqos_js->Has(ownership_str)) {
-    const Nan::Utf8String own(drqos_js->Get(ownership_str));
+  if (Nan::Has(drqos_js, ownership_str).ToChecked()) {
+    const Nan::Utf8String own(Nan::Get(drqos_js, ownership_str).ToLocalChecked());
     if (0 == std::strcmp(*own, "SHARED_OWNERSHIP_QOS")) {
       qos.ownership.kind = DDS::SHARED_OWNERSHIP_QOS;
     } else if (0 == std::strcmp(*own, "EXCLUSIVE_OWNERSHIP_QOS")) {
@@ -436,23 +436,23 @@ void convertQos(DDS::DataReaderQos& qos, const Local<Object>& drqos_js)
     }
   }
 
-  if (drqos_js->Has(tbfilter_str) && drqos_js->Get(tbfilter_str)->IsObject()) {
+  if (Nan::Has(drqos_js, tbfilter_str).ToChecked() && Nan::Get(drqos_js, tbfilter_str).ToLocalChecked()->IsObject()) {
     convert(qos.time_based_filter.minimum_separation,
-            drqos_js->Get(tbfilter_str)->ToObject(Nan::GetCurrentContext()).ToLocalChecked());
+            Nan::Get(drqos_js, tbfilter_str).ToLocalChecked()->ToObject(Nan::GetCurrentContext()).ToLocalChecked());
   }
 
-  if (drqos_js->Has(rdlife_str) && drqos_js->Get(rdlife_str)->IsObject()) {
-    const Local<Object> rdlife = drqos_js->Get(rdlife_str)->ToObject(Nan::GetCurrentContext()).ToLocalChecked();
+  if (Nan::Has(drqos_js, rdlife_str).ToChecked() && Nan::Get(drqos_js, rdlife_str).ToLocalChecked()->IsObject()) {
+    const Local<Object> rdlife = Nan::Get(drqos_js, rdlife_str).ToLocalChecked()->ToObject(Nan::GetCurrentContext()).ToLocalChecked();
     const Local<String> ansd_str =
       Nan::New<String>("autopurge_nowriter_samples_delay").ToLocalChecked(),
       adsd_str = Nan::New<String>("autopurge_disposed_samples_delay").ToLocalChecked();
-    if (rdlife->Has(ansd_str) && rdlife->Get(ansd_str)->IsObject()) {
+    if (Nan::Has(rdlife, ansd_str).ToChecked() && Nan::Get(rdlife, ansd_str).ToLocalChecked()->IsObject()) {
       convert(qos.reader_data_lifecycle.autopurge_nowriter_samples_delay,
-              rdlife->Get(ansd_str)->ToObject(Nan::GetCurrentContext()).ToLocalChecked());
+              Nan::Get(rdlife, ansd_str).ToLocalChecked()->ToObject(Nan::GetCurrentContext()).ToLocalChecked());
     }
-    if (rdlife->Has(adsd_str) && rdlife->Get(adsd_str)->IsObject()) {
+    if (Nan::Has(rdlife, adsd_str).ToChecked() && Nan::Get(rdlife, adsd_str).ToLocalChecked()->IsObject()) {
       convert(qos.reader_data_lifecycle.autopurge_disposed_samples_delay,
-              rdlife->Get(adsd_str)->ToObject(Nan::GetCurrentContext()).ToLocalChecked());
+              Nan::Get(rdlife, adsd_str).ToLocalChecked()->ToObject(Nan::GetCurrentContext()).ToLocalChecked());
     }
   }
 }

--- a/test/.gitignore
+++ b/test/.gitignore
@@ -6,5 +6,6 @@
 *.ilk
 *.pdb
 *.vcxproj*
+*.log
 Debug
 ipch

--- a/test/run_test.pl
+++ b/test/run_test.pl
@@ -10,8 +10,6 @@ use PerlDDS::Run_Test;
 use strict;
 
 my $status = 0;
-#my $dcpsrepo_ior = "repo.ior";
-#unlink $dcpsrepo_ior;
 
 my $test = new PerlDDS::TestFramework();
 
@@ -38,18 +36,6 @@ if (exists($args{"node2cpp"})) {
 }
 
 $test->setup_discovery("-ORBDebugLevel 1 -ORBLogFile DCPSInfoRepo.log") unless $secure;
-
-#my $DCPSREPO;
-#if (not $secure) {
-#  $DCPSREPO = PerlDDS::create_process("$DDS_ROOT/bin/DCPSInfoRepo");
-#
-#  $DCPSREPO->Spawn();
-#  if (PerlACE::waitforfile_timed($dcpsrepo_ior, 30) == -1) {
-#      print STDERR "ERROR: waiting for Info Repo IOR file\n";
-#      $DCPSREPO->Kill();
-#      exit 1;
-#  }
-#}
 
 sub which {
   my $file = shift;
@@ -88,11 +74,6 @@ if ($sub_node) {
 }
 
 $test->process("sub", $sub_exec_name, $sub_args);
-#my $SUB = $test->create_process($sub_exec_name, $sub_args);
-#if ($sub_node) {
-#  $SUB->IgnoreExeSubDir(1);
-#}
-#$SUB->Spawn();
 
 my $pub_exec_name = "";
 my $pub_args = "";
@@ -110,31 +91,6 @@ if ($pub_node) {
 }
 
 $test->process("pub", $pub_exec_name, $pub_args);
-#my $PUB = $test->create_process($pub_exec_name, $pub_args);
-#if ($pub_node) {
-#  $PUB->IgnoreExeSubDir(1);
-#}
-#$my $PubResult = $PUB->SpawnWaitKill(60);
-#if ($PubResult != 0) {
-#    print STDERR "ERROR: " . $pub_exec_name . " returned $PubResult\n";
-#    $status = 1;
-#}
-
-#my $SubResult = $SUB->WaitKill(10);
-#if ($SubResult != 0) {
-#    print STDERR "ERROR: " . $sub_exec_name . " returned $SubResult\n";
-#    $status = 1;
-#}
-
-#if (not $secure) {
-#  my $ir = $DCPSREPO->TerminateWaitKill(5);
-#  if ($ir != 0) {
-#      print STDERR "ERROR: DCPSInfoRepo returned $ir\n";
-#      $status = 1;
-#  }
-#
-#  unlink $dcpsrepo_ior;
-#}
 
 $test->start_process("sub");
 $test->start_process("pub");

--- a/test/run_test.pl
+++ b/test/run_test.pl
@@ -10,8 +10,10 @@ use PerlDDS::Run_Test;
 use strict;
 
 my $status = 0;
-my $dcpsrepo_ior = "repo.ior";
-unlink $dcpsrepo_ior;
+#my $dcpsrepo_ior = "repo.ior";
+#unlink $dcpsrepo_ior;
+
+my $test = new PerlDDS::TestFramework();
 
 print "\nTest: @ARGV\n";
 
@@ -35,17 +37,19 @@ if (exists($args{"node2cpp"})) {
   $sub_node = 0;
 }
 
-my $DCPSREPO;
-if (not $secure) {
-  $DCPSREPO = PerlDDS::create_process("$DDS_ROOT/bin/DCPSInfoRepo");
+$test->setup_discovery("-ORBDebugLevel 1 -ORBLogFile DCPSInfoRepo.log") unless $secure;
 
-  $DCPSREPO->Spawn();
-  if (PerlACE::waitforfile_timed($dcpsrepo_ior, 30) == -1) {
-      print STDERR "ERROR: waiting for Info Repo IOR file\n";
-      $DCPSREPO->Kill();
-      exit 1;
-  }
-}
+#my $DCPSREPO;
+#if (not $secure) {
+#  $DCPSREPO = PerlDDS::create_process("$DDS_ROOT/bin/DCPSInfoRepo");
+#
+#  $DCPSREPO->Spawn();
+#  if (PerlACE::waitforfile_timed($dcpsrepo_ior, 30) == -1) {
+#      print STDERR "ERROR: waiting for Info Repo IOR file\n";
+#      $DCPSREPO->Kill();
+#      exit 1;
+#  }
+#}
 
 sub which {
   my $file = shift;
@@ -66,6 +70,7 @@ if ($^O eq 'darwin') {
 }
 
 PerlDDS::add_lib_path("idl");
+PerlDDS::add_lib_path("../tools/v8stubs");
 
 my $sub_exec_name = "";
 my $sub_args = "";
@@ -82,11 +87,12 @@ if ($sub_node) {
   }
 }
 
-my $SUB = PerlDDS::create_process($sub_exec_name, $sub_args);
-if ($sub_node) {
-  $SUB->IgnoreExeSubDir(1);
-}
-$SUB->Spawn();
+$test->process("sub", $sub_exec_name, $sub_args);
+#my $SUB = $test->create_process($sub_exec_name, $sub_args);
+#if ($sub_node) {
+#  $SUB->IgnoreExeSubDir(1);
+#}
+#$SUB->Spawn();
 
 my $pub_exec_name = "";
 my $pub_args = "";
@@ -103,30 +109,36 @@ if ($pub_node) {
   }
 }
 
-my $PUB = PerlDDS::create_process($pub_exec_name, $pub_args);
-if ($pub_node) {
-  $PUB->IgnoreExeSubDir(1);
-}
-my $PubResult = $PUB->SpawnWaitKill(60);
-if ($PubResult != 0) {
-    print STDERR "ERROR: " . $pub_exec_name . " returned $PubResult\n";
-    $status = 1;
-}
+$test->process("pub", $pub_exec_name, $pub_args);
+#my $PUB = $test->create_process($pub_exec_name, $pub_args);
+#if ($pub_node) {
+#  $PUB->IgnoreExeSubDir(1);
+#}
+#$my $PubResult = $PUB->SpawnWaitKill(60);
+#if ($PubResult != 0) {
+#    print STDERR "ERROR: " . $pub_exec_name . " returned $PubResult\n";
+#    $status = 1;
+#}
 
-my $SubResult = $SUB->WaitKill(10);
-if ($SubResult != 0) {
-    print STDERR "ERROR: " . $sub_exec_name . " returned $SubResult\n";
-    $status = 1;
-}
+#my $SubResult = $SUB->WaitKill(10);
+#if ($SubResult != 0) {
+#    print STDERR "ERROR: " . $sub_exec_name . " returned $SubResult\n";
+#    $status = 1;
+#}
 
-if (not $secure) {
-  my $ir = $DCPSREPO->TerminateWaitKill(5);
-  if ($ir != 0) {
-      print STDERR "ERROR: DCPSInfoRepo returned $ir\n";
-      $status = 1;
-  }
+#if (not $secure) {
+#  my $ir = $DCPSREPO->TerminateWaitKill(5);
+#  if ($ir != 0) {
+#      print STDERR "ERROR: DCPSInfoRepo returned $ir\n";
+#      $status = 1;
+#  }
+#
+#  unlink $dcpsrepo_ior;
+#}
 
-  unlink $dcpsrepo_ior;
-}
+$test->start_process("sub");
+$test->start_process("pub");
+
+exit $test->finish(30);
 
 exit $status;

--- a/test/test_publisher.cpp
+++ b/test/test_publisher.cpp
@@ -184,7 +184,7 @@ int ACE_TMAIN(int argc, ACE_TCHAR* argv[])
     sample.id = 23;
     sample.data = "Hello, world\n";
     sample.enu = Mod::two;
-    sample.enu2 = static_cast<Mod::MyEnum>(42); // invalid enumerator
+    sample.enu2 = Mod::three;
     sample.bt.o = 254;
     sample.bt.us = 65500;
     sample.bt.s = 32700;

--- a/test/test_publisher.js
+++ b/test/test_publisher.js
@@ -57,7 +57,7 @@ function doStuff(writer) {
     id: 23,
     data: "Hello, world\n",
     enu: "two",
-    enu2: 42,
+    enu2: "three",
     bt: {
       o: "254",
       us: 65500,

--- a/test/test_subscriber.cpp
+++ b/test/test_subscriber.cpp
@@ -300,7 +300,7 @@ int ACE_TMAIN(int argc, ACE_TCHAR* argv[])
     if (sample.id != 23 ||
       std::string(sample.data.in()) != "Hello, world\n" ||
       sample.enu != Mod::two ||
-      sample.enu2 != static_cast<Mod::MyEnum>(42) || // invalid enumerator
+      sample.enu2 != Mod::three ||
       sample.bt.o != 254 ||
       sample.bt.us != 65500 ||
       sample.bt.s != 32700 ||
@@ -358,7 +358,7 @@ int ACE_TMAIN(int argc, ACE_TCHAR* argv[])
     if (sample.id != 24 ||
       std::string(sample.data.in()) != "Hello, world\n" ||
       sample.enu != Mod::two ||
-      sample.enu2 != static_cast<Mod::MyEnum>(42) || // invalid enumerator
+      sample.enu2 != Mod::three ||
       sample.bt.o != 254 ||
       sample.bt.us != 65500 ||
       sample.bt.s != 32700 ||

--- a/test/test_subscriber.cpp
+++ b/test/test_subscriber.cpp
@@ -306,7 +306,7 @@ int ACE_TMAIN(int argc, ACE_TCHAR* argv[])
       sample.bt.s != 32700 ||
       sample.bt.ul != 3000000000 ||
       sample.bt.l != 100000 ||
-      sample.bt.ull != 0xABCDEF0123456789ULL ||
+      //sample.bt.ull != 0xABCDEF0123456789ULL ||
       sample.bt.ll != 5000000000LL ||
       sample.bt.f < 2.17f - 1e-3 || sample.bt.f > 2.17f + 1e-3 ||
       sample.bt.d < 3.14 - 1e-6 || sample.bt.d > 3.14 + 1e-6 ||
@@ -364,7 +364,7 @@ int ACE_TMAIN(int argc, ACE_TCHAR* argv[])
       sample.bt.s != 32700 ||
       sample.bt.ul != 3000000000 ||
       sample.bt.l != 100000 ||
-      sample.bt.ull != 0xABCDEF0123456789ULL ||
+      //sample.bt.ull != 0xABCDEF0123456789ULL ||
       sample.bt.ll != 5000000000LL ||
       sample.bt.f < 2.17f - 1e-3 || sample.bt.f > 2.17f + 1e-3 ||
       sample.bt.d < 3.14 - 1e-6 || sample.bt.d > 3.14 + 1e-6 ||

--- a/test/test_subscriber.cpp
+++ b/test/test_subscriber.cpp
@@ -306,7 +306,7 @@ int ACE_TMAIN(int argc, ACE_TCHAR* argv[])
       sample.bt.s != 32700 ||
       sample.bt.ul != 3000000000 ||
       sample.bt.l != 100000 ||
-      //sample.bt.ull != 0xABCDEF0123456789ULL ||
+      sample.bt.ull != 0xABCDEF0123456789ULL ||
       sample.bt.ll != 5000000000LL ||
       sample.bt.f < 2.17f - 1e-3 || sample.bt.f > 2.17f + 1e-3 ||
       sample.bt.d < 3.14 - 1e-6 || sample.bt.d > 3.14 + 1e-6 ||
@@ -364,7 +364,7 @@ int ACE_TMAIN(int argc, ACE_TCHAR* argv[])
       sample.bt.s != 32700 ||
       sample.bt.ul != 3000000000 ||
       sample.bt.l != 100000 ||
-      //sample.bt.ull != 0xABCDEF0123456789ULL ||
+      sample.bt.ull != 0xABCDEF0123456789ULL ||
       sample.bt.ll != 5000000000LL ||
       sample.bt.f < 2.17f - 1e-3 || sample.bt.f > 2.17f + 1e-3 ||
       sample.bt.d < 3.14 - 1e-6 || sample.bt.d > 3.14 + 1e-6 ||

--- a/test/test_subscriber.js
+++ b/test/test_subscriber.js
@@ -106,7 +106,7 @@ try {
         if (!(sample.id == 23 || sample.id == 24) ||
             sample.data != "Hello, world\n" ||
             sample.enu != "two" ||
-            sample.enu2 != "<<invalid>>" ||
+            sample.enu2 != "three" ||
             sample.bt.o != 254 ||
             sample.bt.us != 65500 ||
             sample.bt.us != 65500 ||

--- a/test/test_subscriber.js
+++ b/test/test_subscriber.js
@@ -112,7 +112,7 @@ try {
             sample.bt.s != 32700 ||
             sample.bt.ul != 3000000000 ||
             sample.bt.l != 100000 ||
-            //sample.bt.ull != "12379813738877118345" || // This currently fails due to a truncation error from JS "number". Solution will write 64-bit integers (signed & unsigned) as decimal strings. Uncomment this line once truncation issue is resolved in latest release branch.
+            sample.bt.ull != "12379813738877118345" ||
             sample.bt.ll != 5000000000 ||
             sample.bt.f > (2.17 + 1e-3) || sample.bt.f < (2.17 - 1e-3) || // avoid direct floating point comparisons by testing epsilon ranges
             sample.bt.d > (3.14 + 1e-6) || sample.bt.d < (3.14 - 1e-6) ||

--- a/test/test_subscriber.js
+++ b/test/test_subscriber.js
@@ -109,7 +109,6 @@ try {
             sample.enu2 != "three" ||
             sample.bt.o != 254 ||
             sample.bt.us != 65500 ||
-            sample.bt.us != 65500 ||
             sample.bt.s != 32700 ||
             sample.bt.ul != 3000000000 ||
             sample.bt.l != 100000 ||

--- a/tools/v8stubs/v8stubs.cpp
+++ b/tools/v8stubs/v8stubs.cpp
@@ -5,14 +5,38 @@
 namespace v8 {
   Local<Array> Array::New(Isolate*, int) { return {}; }
   EscapableHandleScope::EscapableHandleScope(Isolate*) {}
+  void* External::Value() const { return 0; }
+
+#if (V8_MAJOR_VERSION < 7)
   internal::Object** EscapableHandleScope::Escape(internal::Object**) {
     return 0;
   }
-  void* External::Value() const { return 0; }
-  internal::Object** HandleScope::CreateHandle(internal::HeapObject*,
-                                                      internal::Object*) {
+  internal::Object** HandleScope::CreateHandle(internal::HeapObject*, internal::Object*) {
     return 0;
   }
+  int String::WriteUtf8(char*, int, int*, int) const { return 0; }
+#else
+  Local<Boolean> Value::ToBoolean(v8::Isolate*) const { return {}; }
+  internal::Address* EscapableHandleScope::Escape(internal::Address*) { return 0; }
+  internal::Address* HandleScope::CreateHandle(v8::internal::Isolate*, unsigned long) { return 0; }
+  namespace internal {
+    Isolate* IsolateFromNeverReadOnlySpaceObject(Address) { return 0; }
+  }
+  int String::WriteUtf8(Isolate*, char*, int, int*, int) const { return 0; }
+#endif
+
+#if (V8_MAJOR_VERSION < 8)
+  bool Object::Set(unsigned int, Local<Value>) { return false; }
+  bool Object::Set(Local<Value>, Local<Value>) { return false; }
+  MaybeLocal<Boolean> Value::ToBoolean(v8::Local<v8::Context>) const { return {}; }
+  Local<Value> Object::Get(Handle<v8::Value>) { return {}; }
+  Local<Value> Object::Get(unsigned int) { return {}; }
+#else
+#endif
+
+  bool Value::IsBoolean() const { return false; }
+  bool Boolean::Value() const { return false; }
+
   HandleScope::~HandleScope() {}
   Local<Integer> Integer::NewFromUnsigned(Isolate*, unsigned int) {
     return {};
@@ -22,8 +46,6 @@ namespace v8 {
   Local<Context> Isolate::GetCurrentContext() { return {}; }
   Local<Number> Number::New(Isolate*, double) { return {}; }
   Local<Object> Object::New(Isolate*) { return {}; }
-  bool Object::Set(unsigned int, Local<Value>) { return false; }
-  bool Object::Set(Local<Value>, Local<Value>) { return false; }
   Local<Value> Object::SlowGetInternalField(int) { return {}; }
   MaybeLocal<String> String::NewFromTwoByte(Isolate*, const uint16_t*,
                                                    v8::NewStringType, int) {
@@ -36,24 +58,21 @@ namespace v8 {
   void V8::ToLocalEmpty() {}
   MaybeLocal<Int32> Value::ToInt32(Local<Context>) const { return {}; }
   MaybeLocal<Uint32> Value::ToUint32(Local<Context>) const { return {}; }
-  int String::WriteUtf8(char*, int, int*, int) const { return 0; }
   bool Value::IsArray() const { return false; }
   MaybeLocal<Number> Value::ToNumber(v8::Local<v8::Context>) const { return {}; }
-  Local<Value> Object::Get(Handle<v8::Value>) { return {}; }
-  bool Value::IsBoolean() const { return false; }
   bool Value::IsNumber() const { return false; }
   int String::Length() const { return 0; }
-  int String::Utf8Length() const { return 0; }
-  int64_t Value::IntegerValue() const { return 0; }
   double Number::Value() const { return 0.0; }
-  bool Boolean::Value() const { return false; }
-  int64_t Integer::Value() const { return false; }
-  bool Object::Has(v8::Local<v8::Value>) { return false; }
+  int64_t Integer::Value() const { return 0l; }
   MaybeLocal<String> Value::ToString(v8::Local<v8::Context>) const { return {}; }
-  int v8::String::Write(unsigned short*, int, int, int) const { return 0; }
   MaybeLocal<Object> Value::ToObject(v8::Local<v8::Context>) const { return {}; }
-  MaybeLocal<Boolean> Value::ToBoolean(v8::Local<v8::Context>) const { return {}; }
   MaybeLocal<Integer> Value::ToInteger(v8::Local<v8::Context>) const { return {}; }
-  Local<Value> Object::Get(unsigned int) { return {}; }
-  uint32_t Value::Uint32Value() const { return 0; }
+  Maybe<bool> Object::Has(v8::Local<v8::Context>, v8::Local<v8::Value>) { return Just(false); }
+  MaybeLocal<Value> Object::Get(v8::Local<v8::Context>, v8::Local<v8::Value>) { return {}; }
+  Maybe<bool> Object::Set(v8::Local<v8::Context>, unsigned int, v8::Local<v8::Value>) { return Just(false); }
+  Maybe<uint32_t> Value::Uint32Value(v8::Local<v8::Context>) const { return Just(0u); }
+  Maybe<bool> Object::Set(v8::Local<v8::Context>, v8::Local<v8::Value>, v8::Local<v8::Value>) { return Just(false); }
+  MaybeLocal<Value> Object::Get(v8::Local<v8::Context>, unsigned int) { return {}; }
+  Maybe<int64_t> Value::IntegerValue(v8::Local<v8::Context>) const { return Just(0l); }
+  HandleScope::HandleScope(v8::Isolate*) {}
 }

--- a/tools/v8stubs/v8stubs.cpp
+++ b/tools/v8stubs/v8stubs.cpp
@@ -63,16 +63,16 @@ namespace v8 {
   bool Value::IsNumber() const { return false; }
   int String::Length() const { return 0; }
   double Number::Value() const { return 0.0; }
-  int64_t Integer::Value() const { return 0l; }
+  int64_t Integer::Value() const { return static_cast<int64_t>(0); }
   MaybeLocal<String> Value::ToString(v8::Local<v8::Context>) const { return {}; }
   MaybeLocal<Object> Value::ToObject(v8::Local<v8::Context>) const { return {}; }
   MaybeLocal<Integer> Value::ToInteger(v8::Local<v8::Context>) const { return {}; }
   Maybe<bool> Object::Has(v8::Local<v8::Context>, v8::Local<v8::Value>) { return Just(false); }
   MaybeLocal<Value> Object::Get(v8::Local<v8::Context>, v8::Local<v8::Value>) { return {}; }
   Maybe<bool> Object::Set(v8::Local<v8::Context>, unsigned int, v8::Local<v8::Value>) { return Just(false); }
-  Maybe<uint32_t> Value::Uint32Value(v8::Local<v8::Context>) const { return Just(0u); }
+  Maybe<uint32_t> Value::Uint32Value(v8::Local<v8::Context>) const { return Just(static_cast<uint32_t>(0)); }
   Maybe<bool> Object::Set(v8::Local<v8::Context>, v8::Local<v8::Value>, v8::Local<v8::Value>) { return Just(false); }
   MaybeLocal<Value> Object::Get(v8::Local<v8::Context>, unsigned int) { return {}; }
-  Maybe<int64_t> Value::IntegerValue(v8::Local<v8::Context>) const { return Just(0l); }
+  Maybe<int64_t> Value::IntegerValue(v8::Local<v8::Context>) const { return Just(static_cast<int64_t>(0)); }
   HandleScope::HandleScope(v8::Isolate*) {}
 }


### PR DESCRIPTION
Problem: OpenDDS changes broke V8 generation for 3.15 and later. Fixes have been made against master, but in the mean time OpenDDS code generation no longer allows setting invalid enumerator values.

Solution: Update tests to avoid invalid enumerators, and increase test coverage here to cover master and other node.js versions.