### PR TITLE
Expose wait_for_acknowledgments in Node.js, Improve Test Logic

### DIFF
--- a/test/rtps_disc.ini
+++ b/test/rtps_disc.ini
@@ -7,7 +7,7 @@ DiscoveryConfig=uni_rtps
 
 [rtps_discovery/uni_rtps]
 SedpMulticast=0
-ResendPeriod=2
+ResendPeriod=1
 
 [transport/the_rtps_transport]
 transport_type=rtps_udp

--- a/test/test_publisher.cpp
+++ b/test/test_publisher.cpp
@@ -212,9 +212,8 @@ int ACE_TMAIN(int argc, ACE_TCHAR* argv[])
       throw return_code;
     }
 
-    if (Utils::wait_match(dw, 0)) {
-      ACE_ERROR_RETURN((LM_ERROR, "test publisher wait_for_match failed\n"), 1);
-    }
+    const DDS::Duration_t delay = {DDS::DURATION_INFINITE_SEC, DDS::DURATION_INFINITE_NSEC};
+    writer->wait_for_acknowledgments(delay);
 
     return_code = writer->dispose(sample, handle);
     if (return_code != DDS::RETCODE_OK) {

--- a/test/test_publisher.cpp
+++ b/test/test_publisher.cpp
@@ -212,6 +212,10 @@ int ACE_TMAIN(int argc, ACE_TCHAR* argv[])
       throw return_code;
     }
 
+    if (Utils::wait_match(dw, 0)) {
+      ACE_ERROR_RETURN((LM_ERROR, "test publisher wait_for_match failed\n"), 1);
+    }
+
     return_code = writer->dispose(sample, handle);
     if (return_code != DDS::RETCODE_OK) {
       throw return_code;

--- a/test/test_publisher.js
+++ b/test/test_publisher.js
@@ -54,6 +54,8 @@ function log(label, object) {
 }
 
 function doStuff(writer) {
+  console.log("writer has waited long enough for association");
+
   var sample1 = {
     id: 23,
     data: "Hello, world\n",
@@ -95,6 +97,8 @@ function doStuff(writer) {
   retcode = writer.write(sample1, handle);
 
   retcode = writer.write(sample2);
+
+  retcode = writer.wait_for_acknowledgments();
 
   retcode = writer.dispose(sample1, handle);
 

--- a/test/test_subscriber.cpp
+++ b/test/test_subscriber.cpp
@@ -381,6 +381,8 @@ int ACE_TMAIN(int argc, ACE_TCHAR* argv[])
       result = 1;
     }
 
+    Utils::wait_match(dr, 0);
+
     participant->delete_contained_entities();
     dpf->delete_participant(participant);
     TheServiceParticipant->shutdown();

--- a/test/test_subscriber.js
+++ b/test/test_subscriber.js
@@ -51,6 +51,11 @@ function log(label, object) {
   console.log(label + ': ' + JSON.stringify(object, null, 2));
 }
 
+function doStuff(participant, reader) {
+  console.log("reader has waited long enough for acknowledgments");
+  participant.unsubscribe(reader);
+}
+
 try {
   if (!library) {
     throw 'Failed to load shared library';
@@ -155,7 +160,7 @@ try {
           process.exitCode = 1;
         }
         if (sample.id == last_sample_id) {
-          participant.unsubscribe(reader);
+          setTimeout(function () { doStuff(participant, dr); }, 3000);
         }
       }
     } catch (e) {

--- a/test/test_subscriber.js
+++ b/test/test_subscriber.js
@@ -100,10 +100,9 @@ try {
     }
   }, function (dr, sinfo, sample) {
     try {
-      log('Received callback', sample);
       log('Sample Info', sinfo);
-      if (sinfo.valid_data && sample.id == last_sample_id) {
-        participant.unsubscribe(reader);
+      if (sinfo.valid_data) {
+        log('Received callback', sample);
         if (!(sample.id == 23 || sample.id == 24) ||
             sample.data != "Hello, world\n" ||
             sample.enu != "two" ||
@@ -154,6 +153,9 @@ try {
             (sample.id == 24 && (sample.mu._d != "four" || sample.mu.s.length != 2 || sample.mu.s[0].length != 4 || sample.mu.s[1].length != 1))) {
           console.log("Error in data!");
           process.exitCode = 1;
+        }
+        if (sample.id == last_sample_id) {
+          participant.unsubscribe(reader);
         }
       }
     } catch (e) {


### PR DESCRIPTION
Problems:
- Node.js datareader did not correctly handle non-valid samples / checking for last sample to unsubscribe
- C++ datawriter did not wait for subscriber to acknowledge second sample before disposing / unregistering
- Node.js also did not wait for subscriber, partly because no Node.js API was defined for wait_for_acknowledgments

Solution:
- Allow / Correctly handle non-valid sample data in the Node.js test_subscriber
- Have the C++ datawriter wait for acknowledgement after second sample before proceeding
- Expose Node.js wait_for_acknowledgments
- Have the Node.js test_publisher wait_for_acknowledgements from test_subscriber before dispose/unregister