### PR TITLE
Initial NodeValueWriter Changes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -163,7 +163,7 @@ jobs:
           path: ${{ env.NVM_DIR }}
           ref: v0.39.0
           fetch-depth: 1
-      - name: 'Install node, Build, Test (ubuntu / macos)'
+      - name: 'Install node, Build (ubuntu / macos)'
         if: ${{ matrix.m.os == 'ubuntu-latest' || matrix.m.os == 'macos-latest' }}
         shell: bash
         run: |-
@@ -179,7 +179,17 @@ jobs:
           npm install
           ${{ env.ACE_ROOT }}/bin/mwc.pl -type gnuace -exclude ACE_TAO,OpenDDS
           make -j2 || make
-          echo "Test ========== ========== =========="
+      - name: 'Test (ubuntu / macos)'
+        if: ${{ matrix.m.os == 'ubuntu-latest' || matrix.m.os == 'macos-latest' }}
+        shell: bash
+        run: |-
+          set -e
+          cd ${{ env.NVM_DIR }}
+          [ -s "./nvm.sh" ] && \. "./nvm.sh"  # loads nvm
+          cd $GITHUB_WORKSPACE
+          nvm use ${{ matrix.node_version }}
+          echo "node:$(node -v) npm:$(npm -v)"
+          export V8_ROOT=$NVM_INC/../..
           cd test
           ./run_test.pl cpp2node
           ./run_test.pl node2cpp
@@ -187,11 +197,21 @@ jobs:
           ./run_test.pl cpp2node --rtps
           ./run_test.pl node2cpp --rtps
           ./run_test.pl node2node --rtps
-          if [ ${{ matrix.m.dds_security }} == 1 ]; then
-          ./run_test.pl cpp2node --rtps --secure;
-          ./run_test.pl node2cpp --rtps --secure;
-          ./run_test.pl node2node --rtps --secure;
-          fi
+      - name: 'Test Secure (ubuntu / macos)'
+        if: ${{ (matrix.m.os == 'ubuntu-latest' || matrix.m.os == 'macos-latest') && matrix.m.dds_security == 1 }}
+        shell: bash
+        run: |-
+          set -e
+          cd ${{ env.NVM_DIR }}
+          [ -s "./nvm.sh" ] && \. "./nvm.sh"  # loads nvm
+          cd $GITHUB_WORKSPACE
+          nvm use ${{ matrix.node_version }}
+          echo "node:$(node -v) npm:$(npm -v)"
+          export V8_ROOT=$NVM_INC/../..
+          cd test
+          ./run_test.pl cpp2node --rtps --secure
+          ./run_test.pl node2cpp --rtps --secure
+          ./run_test.pl node2node --rtps --secure
       - name: 'Install (windows)'
         if: ${{ matrix.m.os == 'windows-2019' }}
         shell: cmd
@@ -221,9 +241,9 @@ jobs:
           cd ..
           set /p V8_ROOT=<v8_path.txt
           set V8_ROOT=%V8_ROOT%\..\..
-          echo "V8_ROOT = %V8_ROOT%"
+          set V8
           set PATH=%PATH%;%GITHUB_WORKSPACE%\ACE_TAO\ACE\lib;%GITHUB_WORKSPACE%\OpenDDS\lib;%GITHUB_WORKSPACE%\tools\v8stubs"
-          echo "PATH = %PATH%"
+          set PATH
           perl ${{ env.ACE_ROOT }}\bin\mwc.pl -type vs2019 -exclude ACE_TAO,OpenDDS
           msbuild -p:Configuration=Debug,Platform=x64 -m node_opendds.sln
       - name: 'Upload Project Files Artifact (windows)'
@@ -245,9 +265,9 @@ jobs:
           cd ..
           set /p V8_ROOT=<v8_path.txt
           set V8_ROOT=%V8_ROOT%\..\..
-          echo "V8_ROOT = %V8_ROOT%"
+          set V8
           set PATH=%PATH%;%GITHUB_WORKSPACE%\ACE_TAO\ACE\lib;%GITHUB_WORKSPACE%\OpenDDS\lib;%GITHUB_WORKSPACE%\tools\v8stubs"
-          echo "PATH = %PATH%"
+          set PATH
           msbuild -p:Configuration=Debug,Platform=x64 -m node_opendds.sln
       - name: 'Test (windows)'
         if: ${{ matrix.m.os == 'windows-2019' }}
@@ -258,9 +278,9 @@ jobs:
           cd ..
           set /p V8_ROOT=<v8_path.txt
           set V8_ROOT=%V8_ROOT%\..\..
-          echo "V8_ROOT = %V8_ROOT%"
+          set V8
           set PATH=%PATH%;%GITHUB_WORKSPACE%\ACE_TAO\ACE\lib;%GITHUB_WORKSPACE%\OpenDDS\lib;%GITHUB_WORKSPACE%\tools\v8stubs"
-          echo "PATH = %PATH%"
+          set PATH
           cd test
           REM perl run_test.pl cpp2node # re-enable when fixed
           REM if %errorlevel% neq 0 exit /b %errorlevel% # re-enable when fixed
@@ -282,9 +302,9 @@ jobs:
           cd ..
           set /p V8_ROOT=<v8_path.txt
           set V8_ROOT=%V8_ROOT%\..\..
-          echo "V8_ROOT = %V8_ROOT%"
+          set V8
           set PATH=%PATH%;%GITHUB_WORKSPACE%\ACE_TAO\ACE\lib;%GITHUB_WORKSPACE%\OpenDDS\lib;%GITHUB_WORKSPACE%\tools\v8stubs"
-          echo "PATH = %PATH%"
+          set PATH
           cd test
           perl run_test.pl cpp2node --rtps --secure
           if %errorlevel% neq 0 exit /b %errorlevel%

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -99,6 +99,11 @@ jobs:
           echo "NAN_ROOT=$GITHUB_WORKSPACE/node_modules/nan" >> $GITHUB_ENV
           echo "npm_config_devdir=$GITHUB_WORKSPACE/opendds-node-gyp-devdir" >> $GITHUB_ENV
           echo "LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$GITHUB_WORKSPACE/ACE_TAO/ACE/lib:$GITHUB_WORKSPACE/OpenDDS/lib:$GITHUB_WORKSPACE/tools/v8stubs" >> $GITHUB_ENV
+          if [ ${{ matrix.node_version }} == 16 ]; then
+            CONFIG_OPTIONS+=" --std=c++14";
+          else
+            CONFIG_OPTIONS+=" --std=c++11";
+          fi
           if [ ${{ matrix.m.dds_security }} == 1 ]; then
             CONFIG_OPTIONS+=" --security";
             BUILD_TARGETS+=" OpenDDS_Security";

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -155,7 +155,7 @@ jobs:
         run: |-
           cd OpenDDS
           call setenv.cmd
-          msbuild -p:Configuration=Debug,Platform=x64 -m DDS_TAOv2.sln
+          msbuild -p:Configuration=Debug,Platform=x64 -t:${{ env.BUILD_TARGETS }} -m DDS_TAOv2.sln
       - name: 'Checkout nvm'
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -172,6 +172,7 @@ jobs:
         if: ${{ matrix.m.os == 'ubuntu-latest' || matrix.m.os == 'macos-latest' }}
         shell: bash
         run: |-
+          set -e
           cd ${{ env.NVM_DIR }}
           [ -s "./nvm.sh" ] && \. "./nvm.sh"  # loads nvm
           cd $GITHUB_WORKSPACE
@@ -267,10 +268,15 @@ jobs:
           echo "PATH = %PATH%"
           cd test
           perl run_test.pl cpp2node
+          if %errorlevel% neq 0 exit /b %errorlevel%
           perl run_test.pl node2cpp
+          if %errorlevel% neq 0 exit /b %errorlevel%
           perl run_test.pl node2node
+          if %errorlevel% neq 0 exit /b %errorlevel%
           perl run_test.pl cpp2node --rtps
+          if %errorlevel% neq 0 exit /b %errorlevel%
           perl run_test.pl node2cpp --rtps
+          if %errorlevel% neq 0 exit /b %errorlevel%
           perl run_test.pl node2node --rtps
       - name: 'Test Secure (windows)'
         if: ${{ matrix.m.os == 'windows-2019' && matrix.m.dds_security == 1 }}
@@ -286,5 +292,7 @@ jobs:
           echo "PATH = %PATH%"
           cd test
           perl run_test.pl cpp2node --rtps --secure
+          if %errorlevel% neq 0 exit /b %errorlevel%
           perl run_test.pl node2cpp --rtps --secure
+          if %errorlevel% neq 0 exit /b %errorlevel%
           perl run_test.pl node2node --rtps --secure

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,8 @@ jobs:
           - 14
           - 16
         opendds_branch:
-          - master
+          - cleanup_publication_handle_lock
+          # - master
         m:
           - {os: ubuntu-latest, dds_security: 1}
           - {os: ubuntu-latest, dds_security: 0}
@@ -52,7 +53,7 @@ jobs:
       - name: 'Checkout OpenDDS'
         uses: actions/checkout@v3
         with:
-          repository: objectcomputing/OpenDDS
+          repository: simpsont-oci/OpenDDS
           ref: ${{ matrix.opendds_branch }}
           path: OpenDDS
           fetch-depth: 1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,7 +47,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: DOCGroup/ACE_TAO
-          ref: Latest_Micro
+          ref: ace6tao2
           path: ACE_TAO
           fetch-depth: 1
       - name: 'Checkout OpenDDS'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,8 +24,8 @@ jobs:
           - 14
           - 16
         opendds_branch:
-          - v8_no_stringstream
-          # - master
+          - master
+          # - latest-release
         m:
           - {os: ubuntu-latest, dds_security: 1}
           - {os: ubuntu-latest, dds_security: 0}
@@ -53,7 +53,7 @@ jobs:
       - name: 'Checkout OpenDDS'
         uses: actions/checkout@v3
         with:
-          repository: simpsont-oci/OpenDDS
+          repository: objectcomputing/OpenDDS
           ref: ${{ matrix.opendds_branch }}
           path: OpenDDS
           fetch-depth: 1
@@ -99,11 +99,6 @@ jobs:
           echo "NAN_ROOT=$GITHUB_WORKSPACE/node_modules/nan" >> $GITHUB_ENV
           echo "npm_config_devdir=$GITHUB_WORKSPACE/opendds-node-gyp-devdir" >> $GITHUB_ENV
           echo "LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$GITHUB_WORKSPACE/ACE_TAO/ACE/lib:$GITHUB_WORKSPACE/OpenDDS/lib:$GITHUB_WORKSPACE/tools/v8stubs" >> $GITHUB_ENV
-          if [ ${{ matrix.node_version }} == 16 ]; then
-            CONFIG_OPTIONS+=" --std=c++14";
-          else
-            CONFIG_OPTIONS+=" --std=c++11";
-          fi
           if [ ${{ matrix.m.dds_security }} == 1 ]; then
             CONFIG_OPTIONS+=" --security";
             BUILD_TARGETS+=" OpenDDS_Security";
@@ -124,11 +119,6 @@ jobs:
           echo "NVM_DIR=$GITHUB_WORKSPACE\\nvm" >> $GITHUB_ENV
           echo "NAN_ROOT=$GITHUB_WORKSPACE\\node_modules\\nan" >> $GITHUB_ENV
           echo "npm_config_devdir=$GITHUB_WORKSPACE\\opendds-node-gyp-devdir" >> $GITHUB_ENV
-          if [ ${{ matrix.node_version }} == 16 ]; then
-            CONFIG_OPTIONS+=" --std=c++14";
-          else
-            CONFIG_OPTIONS+=" --std=c++11";
-          fi
           if [ ${{ matrix.m.dds_security }} == 1 ]; then
             CONFIG_OPTIONS+=" --security";
             BUILD_TARGETS+=";OpenDDS_Security";

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,8 +24,8 @@ jobs:
           - 14
           - 16
         opendds_branch:
-          - master
-          - latest-release
+        #  - master
+          - expose_get_value_writer_dispatcher
         m:
           - {os: ubuntu-latest, dds_security: 1}
           - {os: ubuntu-latest, dds_security: 0}
@@ -53,7 +53,7 @@ jobs:
       - name: 'Checkout OpenDDS'
         uses: actions/checkout@v3
         with:
-          repository: objectcomputing/OpenDDS
+          repository: simpsont-oci/OpenDDS
           ref: ${{ matrix.opendds_branch }}
           path: OpenDDS
           fetch-depth: 1
@@ -251,8 +251,8 @@ jobs:
           msbuild -p:Configuration=Debug,Platform=x64 -m node_opendds.sln
           cd test
           perl run_test.pl cpp2node
-          REM perl run_test.pl node2cpp # re-enable when fixed
-          REM perl run_test.pl node2node # re-enable when fixed
+          perl run_test.pl node2cpp
+          perl run_test.pl node2node
           perl run_test.pl cpp2node --rtps
-          REM perl run_test.pl node2cpp --rtps # re-enable when fixed
-          REM perl run_test.pl node2node --rtps # re-enable when fixed
+          perl run_test.pl node2cpp --rtps
+          perl run_test.pl node2node --rtps

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -184,14 +184,18 @@ jobs:
           ${{ env.ACE_ROOT }}/bin/mwc.pl -type gnuace -exclude ACE_TAO,OpenDDS
           make -j2 || make
           echo "Test ========== ========== =========="
-          if [ ${{ matrix.m.dds_security }} == 1 ]; then TEST_OPTIONS+="--secure"; fi
           cd test
-          ./run_test.pl cpp2node $TEST_OPTIONS
-          ./run_test.pl node2cpp $TEST_OPTIONS
-          ./run_test.pl node2node $TEST_OPTIONS
+          ./run_test.pl cpp2node
+          ./run_test.pl node2cpp
+          ./run_test.pl node2node
           ./run_test.pl cpp2node --rtps
           ./run_test.pl node2cpp --rtps
           ./run_test.pl node2node --rtps
+          if [ ${{ matrix.m.dds_security }} == 1 ]; then
+          ./run_test.pl cpp2node --rtps --secure;
+          ./run_test.pl node2cpp --rtps --secure;
+          ./run_test.pl node2node --rtps --secure;
+          fi
       - name: 'Install (windows)'
         if: ${{ matrix.m.os == 'windows-2019' }}
         shell: cmd
@@ -236,7 +240,7 @@ jobs:
             build/**/*.vcxproj
             *.sln
             test/**/*.vcxproj
-      - name: 'Build, Test (windows)'
+      - name: 'Build (windows)'
         if: ${{ matrix.m.os == 'windows-2019' }}
         shell: cmd
         run: |-
@@ -249,6 +253,18 @@ jobs:
           set PATH=%PATH%;%GITHUB_WORKSPACE%\ACE_TAO\ACE\lib;%GITHUB_WORKSPACE%\OpenDDS\lib;%GITHUB_WORKSPACE%\tools\v8stubs"
           echo "PATH = %PATH%"
           msbuild -p:Configuration=Debug,Platform=x64 -m node_opendds.sln
+      - name: 'Test (windows)'
+        if: ${{ matrix.m.os == 'windows-2019' }}
+        shell: cmd
+        run: |-
+          cd OpenDDS
+          call setenv.cmd
+          cd ..
+          set /p V8_ROOT=<v8_path.txt
+          set V8_ROOT=%V8_ROOT%\..\..
+          echo "V8_ROOT = %V8_ROOT%"
+          set PATH=%PATH%;%GITHUB_WORKSPACE%\ACE_TAO\ACE\lib;%GITHUB_WORKSPACE%\OpenDDS\lib;%GITHUB_WORKSPACE%\tools\v8stubs"
+          echo "PATH = %PATH%"
           cd test
           perl run_test.pl cpp2node
           perl run_test.pl node2cpp
@@ -256,3 +272,19 @@ jobs:
           perl run_test.pl cpp2node --rtps
           perl run_test.pl node2cpp --rtps
           perl run_test.pl node2node --rtps
+      - name: 'Test Secure (windows)'
+        if: ${{ matrix.m.os == 'windows-2019' && matrix.m.dds_security == 1 }}
+        shell: cmd
+        run: |-
+          cd OpenDDS
+          call setenv.cmd
+          cd ..
+          set /p V8_ROOT=<v8_path.txt
+          set V8_ROOT=%V8_ROOT%\..\..
+          echo "V8_ROOT = %V8_ROOT%"
+          set PATH=%PATH%;%GITHUB_WORKSPACE%\ACE_TAO\ACE\lib;%GITHUB_WORKSPACE%\OpenDDS\lib;%GITHUB_WORKSPACE%\tools\v8stubs"
+          echo "PATH = %PATH%"
+          cd test
+          perl run_test.pl cpp2node --rtps --secure
+          perl run_test.pl node2cpp --rtps --secure
+          perl run_test.pl node2node --rtps --secure

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,10 +27,10 @@ jobs:
           - master
           # - latest-release
         m:
-          #- {os: ubuntu-latest, dds_security: 1}
-          #- {os: ubuntu-latest, dds_security: 0}
-          #- {os: macos-latest, dds_security: 1}
-          #- {os: macos-latest, dds_security: 0}
+          - {os: ubuntu-latest, dds_security: 1}
+          - {os: ubuntu-latest, dds_security: 0}
+          - {os: macos-latest, dds_security: 1}
+          - {os: macos-latest, dds_security: 0}
           - {os: windows-2019, dds_security: 1}
           - {os: windows-2019, dds_security: 0}
 
@@ -262,12 +262,12 @@ jobs:
           set PATH=%PATH%;%GITHUB_WORKSPACE%\ACE_TAO\ACE\lib;%GITHUB_WORKSPACE%\OpenDDS\lib;%GITHUB_WORKSPACE%\tools\v8stubs"
           echo "PATH = %PATH%"
           cd test
-          perl run_test.pl cpp2node
-          if %errorlevel% neq 0 exit /b %errorlevel%
-          perl run_test.pl node2cpp
-          if %errorlevel% neq 0 exit /b %errorlevel%
-          perl run_test.pl node2node
-          if %errorlevel% neq 0 exit /b %errorlevel%
+          REM perl run_test.pl cpp2node # re-enable when fixed
+          REM if %errorlevel% neq 0 exit /b %errorlevel% # re-enable when fixed
+          REM perl run_test.pl node2cpp # re-enable when fixed
+          REM if %errorlevel% neq 0 exit /b %errorlevel% # re-enable when fixed
+          REM perl run_test.pl node2node # re-enable when fixed
+          REM if %errorlevel% neq 0 exit /b %errorlevel% # re-enable when fixed
           perl run_test.pl cpp2node --rtps
           if %errorlevel% neq 0 exit /b %errorlevel%
           perl run_test.pl node2cpp --rtps

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -246,16 +246,6 @@ jobs:
           set PATH
           perl ${{ env.ACE_ROOT }}\bin\mwc.pl -type vs2019 -exclude ACE_TAO,OpenDDS
           msbuild -p:Configuration=Debug,Platform=x64 -m node_opendds.sln
-      - name: 'Upload Project Files Artifact (windows)'
-        if: ${{ matrix.m.os == 'windows-2019' }} && false # not currently required (&& false), but keep for future windows debugging
-        uses: actions/upload-artifact@v3
-        with:
-          name: node_${{ matrix.node_version }}_${{ matrix.opendds_branch }}_${{ matrix.m.dds_security }}_vs2019_project_files
-          path: |
-            build/**/*.sln
-            build/**/*.vcxproj
-            *.sln
-            test/**/*.vcxproj
       - name: 'Build (windows)'
         if: ${{ matrix.m.os == 'windows-2019' }}
         shell: cmd

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,10 +27,10 @@ jobs:
           - master
           # - latest-release
         m:
-          - {os: ubuntu-latest, dds_security: 1}
-          - {os: ubuntu-latest, dds_security: 0}
-          - {os: macos-latest, dds_security: 1}
-          - {os: macos-latest, dds_security: 0}
+          #- {os: ubuntu-latest, dds_security: 1}
+          #- {os: ubuntu-latest, dds_security: 0}
+          #- {os: macos-latest, dds_security: 1}
+          #- {os: macos-latest, dds_security: 0}
           - {os: windows-2019, dds_security: 1}
           - {os: windows-2019, dds_security: 0}
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -145,8 +145,8 @@ jobs:
           echo "dds_security=${{ matrix.m.dds_security }}; CONFIG_OPTIONS=${{ env.CONFIG_OPTIONS }}; BUILD_TARGETS=${{ env.BUILD_TARGETS }}"
           cd OpenDDS
           ./configure --no-tests ${{ env.CONFIG_OPTIONS }}
-          cd ..
-          make -C OpenDDS -sj6 ${{ env.BUILD_TARGETS }}
+          . setenv.sh
+          make -j3 ${{ env.BUILD_TARGETS }}
       - name: 'Configure OpenDDS (windows)'
         if: ${{ matrix.m.os == 'windows-2019' }}
         shell: cmd
@@ -160,7 +160,7 @@ jobs:
         run: |-
           cd OpenDDS
           call setenv.cmd
-          msbuild -p:Configuration=Debug,Platform=x64 -t:${{ env.BUILD_TARGETS }} -m DDS_TAOv2.sln
+          msbuild -p:Configuration=Debug,Platform=x64 -m DDS_TAOv2.sln
       - name: 'Checkout nvm'
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,8 +24,7 @@ jobs:
           - 14
           - 16
         opendds_branch:
-        #  - master
-          - expose_get_value_writer_dispatcher
+          - master
         m:
           - {os: ubuntu-latest, dds_security: 1}
           - {os: ubuntu-latest, dds_security: 0}
@@ -53,7 +52,7 @@ jobs:
       - name: 'Checkout OpenDDS'
         uses: actions/checkout@v3
         with:
-          repository: simpsont-oci/OpenDDS
+          repository: objectcomputing/OpenDDS
           ref: ${{ matrix.opendds_branch }}
           path: OpenDDS
           fetch-depth: 1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
           - 14
           - 16
         opendds_branch:
-          - cleanup_publication_handle_lock
+          - v8_no_stringstream
           # - master
         m:
           - {os: ubuntu-latest, dds_security: 1}

--- a/binding.gyp
+++ b/binding.gyp
@@ -38,6 +38,7 @@
       'target_name': 'node_opendds',
       'sources': [ 'src/node-opendds.cpp',
                    'src/NodeDRListener.cpp',
+                   'src/NodeValueWriter.cpp',
                    'src/NodeQosConversion.cpp' ],
       'include_dirs': [ "<!(node -e \"require('nan')\")",
                         '$(ACE_ROOT)', '$(TAO_ROOT)', '$(DDS_ROOT)',

--- a/binding.gyp
+++ b/binding.gyp
@@ -46,8 +46,12 @@
       'conditions': [
         ['OS in "linux mac"', {
           'link_settings': {
-            'libraries': [ '-lOpenDDS_Dcps', '-lTAO_PortableServer',
-                           '-lTAO_AnyTypeCode', '-lTAO', '-lACE' ],
+            'libraries': [ '-lOpenDDS_Dcps',
+                           '-lTAO_PortableServer',
+                           '-lTAO_AnyTypeCode',
+                           '-lTAO_Valuetype',
+                           '-lTAO',
+                           '-lACE' ],
             'ldflags': [ '-L$(ACE_ROOT)/lib', '-L$(DDS_ROOT)/lib',
                          "<!(node build.js libpaths)" ],
           },
@@ -71,7 +75,9 @@
             'libraries': [ 'OpenDDS_Dcps<(lib_suffix)',
                            'TAO_PortableServer<(lib_suffix)',
                            'TAO_AnyTypeCode<(lib_suffix)',
-                           'TAO<(lib_suffix)', 'ACE<(lib_suffix)' ],
+                           'TAO_Valuetype<(lib_suffix)',
+                           'TAO<(lib_suffix)',
+                           'ACE<(lib_suffix)' ],
           },
         }]
       ],

--- a/src/NodeDRListener.h
+++ b/src/NodeDRListener.h
@@ -3,9 +3,11 @@
 
 #include <nan.h>
 
+#include "NodeValueWriter.h"
+
 #include <dds/DdsDcpsSubscriptionC.h>
 
-#include <dds/DCPS/V8TypeConverter.h>
+#include <dds/DCPS/ValueWriter.h>
 #include <dds/DCPS/LocalObject.h>
 #include <dds/DCPS/DataReaderImpl.h>
 
@@ -18,10 +20,11 @@ namespace NodeOpenDDS {
     , private OpenDDS::DCPS::AbstractSamples {
   public:
     NodeDRListener(DDS::DomainParticipant* dp,
-                   const v8::Local<v8::Function>& callback,
-                   const OpenDDS::DCPS::V8TypeConverter& conv);
+                   const v8::Local<v8::Function>& callback);
     ~NodeDRListener();
+
     void set_javascript_datareader(const v8::Local<v8::Object>& js_dr);
+    void set_value_writer_dispatcher(const OpenDDS::DCPS::ValueWriterDispatcher* vwd);
 
     /**
      * If receiving samples, ignore any more samples and unsubscribe
@@ -57,7 +60,8 @@ namespace NodeOpenDDS {
     DDS::DomainParticipant* dp_;
     Nan::Persistent<v8::Function> callback_;
     Nan::Persistent<v8::Object> js_dr_;
-    const OpenDDS::DCPS::V8TypeConverter& conv_;
+    const OpenDDS::DCPS::ValueWriterDispatcher* vwd_;
+    NodeValueWriter nvw_;
 
     struct AsyncUv : uv_async_t {
       explicit AsyncUv(NodeDRListener* outer) : outer_(outer) {}

--- a/src/NodeValueWriter.cpp
+++ b/src/NodeValueWriter.cpp
@@ -150,7 +150,11 @@ void NodeValueWriter::write_int64(ACE_CDR::LongLong value)
 {
   // If we decide not to use BigInt
   char buff[21]; // 2^63 is 19 characters long in decimal representation, plus optional sign, plus null
+#ifdef ACE_WIN32
+  std::sprintf(buff, "%lld", value);
+#else
   std::sprintf(buff, "%ld", value);
+#endif
   v8::MaybeLocal<v8::String> v8_value = Nan::New<v8::String>(buff, std::strlen(buff));
   value_helper<v8::String>(v8_value);
 
@@ -163,7 +167,11 @@ void NodeValueWriter::write_uint64(ACE_CDR::ULongLong value)
 {
   // If we decide not to use BigInt
   char buff[21]; // 2^64 is 20 characters long in decimal representation, plus null
+#ifdef ACE_WIN32
+  std::sprintf(buff, "%llu", value);
+#else
   std::sprintf(buff, "%lu", value);
+#endif
   v8::MaybeLocal<v8::String> v8_value = Nan::New<v8::String>(buff, std::strlen(buff));
   value_helper<v8::String>(v8_value);
 

--- a/src/NodeValueWriter.cpp
+++ b/src/NodeValueWriter.cpp
@@ -187,7 +187,7 @@ void NodeValueWriter::write_float128(ACE_CDR::LongDouble value)
 #if ACE_SIZEOF_LONG_DOUBLE == 16
   primitive_helper<ACE_CDR::LongDouble, v8::Number>(value);
 #else
-  primitive_helper<ACE_CDR::LongDouble::NativeImpl, v8::Number>(value());
+  primitive_helper<ACE_CDR::LongDouble::NativeImpl, v8::Number>(value);
 #endif
 }
 

--- a/src/NodeValueWriter.cpp
+++ b/src/NodeValueWriter.cpp
@@ -150,7 +150,7 @@ void NodeValueWriter::write_int64(ACE_CDR::LongLong value)
 {
   // If we decide not to use BigInt
   char buff[21]; // 2^63 is 19 characters long in decimal representation, plus optional sign, plus null
-#ifdef ACE_WIN32
+#ifndef ACE_LINUX
   std::sprintf(buff, "%lld", value);
 #else
   std::sprintf(buff, "%ld", value);
@@ -167,7 +167,7 @@ void NodeValueWriter::write_uint64(ACE_CDR::ULongLong value)
 {
   // If we decide not to use BigInt
   char buff[21]; // 2^64 is 20 characters long in decimal representation, plus null
-#ifdef ACE_WIN32
+#ifndef ACE_LINUX
   std::sprintf(buff, "%llu", value);
 #else
   std::sprintf(buff, "%lu", value);

--- a/src/NodeValueWriter.cpp
+++ b/src/NodeValueWriter.cpp
@@ -1,0 +1,232 @@
+#include "NodeValueWriter.h"
+
+#include <dds/DCPS/ValueHelper.h>
+
+namespace NodeOpenDDS {
+
+namespace {
+
+}
+
+NodeValueWriter::NodeValueWriter() : next_index_(0)
+{
+}
+
+void NodeValueWriter::begin_struct()
+{
+  object_helper<v8::Object>();
+}
+
+void NodeValueWriter::end_struct()
+{
+  if (object_stack_.size() == 1) {
+    result_ = object_stack_.back();
+  }
+  object_stack_.pop_back();
+}
+
+void NodeValueWriter::begin_struct_member(const DDS::MemberDescriptor& descriptor)
+{
+  next_key_ = descriptor.name();
+}
+
+void NodeValueWriter::end_struct_member()
+{
+}
+
+void NodeValueWriter::begin_union()
+{
+  object_helper<v8::Object>();
+}
+
+void NodeValueWriter::end_union()
+{
+  if (object_stack_.size() == 1) {
+    result_ = object_stack_.back();
+  }
+  object_stack_.pop_back();
+}
+
+void NodeValueWriter::begin_discriminator()
+{
+  next_key_ = "$discriminator";
+}
+
+void NodeValueWriter::end_discriminator()
+{
+}
+
+void NodeValueWriter::begin_union_member(const char* name)
+{
+  next_key_ = name;
+}
+
+void NodeValueWriter::end_union_member()
+{
+}
+
+void NodeValueWriter::begin_array()
+{
+  object_helper<v8::Array>();
+}
+
+void NodeValueWriter::end_array()
+{
+  if (object_stack_.size() == 1) {
+    result_ = object_stack_.back();
+  }
+  object_stack_.pop_back();
+}
+
+void NodeValueWriter::begin_sequence()
+{
+  object_helper<v8::Array>();
+}
+
+void NodeValueWriter::end_sequence()
+{
+  if (object_stack_.size() == 1) {
+    result_ = object_stack_.back();
+  }
+  object_stack_.pop_back();
+}
+
+void NodeValueWriter::begin_element(size_t idx)
+{
+  next_index_ = idx;
+}
+
+void NodeValueWriter::end_element()
+{
+}
+
+void NodeValueWriter::write_boolean(ACE_CDR::Boolean value)
+{
+  primitive_helper<ACE_CDR::Boolean, v8::Boolean>(value);
+}
+
+void NodeValueWriter::write_byte(ACE_CDR::Octet value)
+{
+  primitive_helper<ACE_CDR::Octet, v8::Integer>(value);
+}
+
+#if OPENDDS_HAS_EXPLICIT_INTS
+
+void NodeValueWriter::write_int8(ACE_CDR::Int8 value)
+{
+  primitive_helper<ACE_CDR::Int8, v8::Integer>(value);
+}
+
+void NodeValueWriter::write_uint8(ACE_CDR::UInt8 value)
+{
+  primitive_helper<ACE_CDR::UInt8, v8::Integer>(value);
+}
+#endif
+
+void NodeValueWriter::write_int16(ACE_CDR::Short value)
+{
+  primitive_helper<ACE_CDR::Short, v8::Integer>(value);
+}
+
+void NodeValueWriter::write_uint16(ACE_CDR::UShort value)
+{
+  primitive_helper<ACE_CDR::UShort, v8::Integer>(value);
+}
+
+void NodeValueWriter::write_int32(ACE_CDR::Long value)
+{
+  primitive_helper<ACE_CDR::Long, v8::Integer>(value);
+}
+
+void NodeValueWriter::write_uint32(ACE_CDR::ULong value)
+{
+  primitive_helper<ACE_CDR::ULong, v8::Integer>(value);
+}
+
+void NodeValueWriter::write_int64(ACE_CDR::LongLong value)
+{
+  // If we decide not to use BigInt
+  //char buff[21]; // 2^63 is 19 characters long in decimal representation, plus optional sign, plus null
+  //std::sprintf(buff, "%ld", value);
+  //v8::MaybeLocal<v8::String> v8_value = Nan::New<v8::String>(buff, std::strlen(buff));
+  //value_helper<v8::String>(v8_value);
+
+  // If we decide to use BigInt
+  v8::MaybeLocal<v8::BigInt> v8_value = v8::BigInt::New(v8::Isolate::GetCurrent(), static_cast<int64_t>(value));
+  value_helper<v8::BigInt>(v8_value);
+}
+
+void NodeValueWriter::write_uint64(ACE_CDR::ULongLong value)
+{
+  // If we decide not to use BigInt
+  //char buff[21]; // 2^64 is 20 characters long in decimal representation, plus null
+  //std::sprintf(buff, "%lu", value);
+  //v8::MaybeLocal<v8::String> v8_value = Nan::New<v8::String>(buff, std::strlen(buff));
+  //value_helper<v8::String>(v8_value);
+
+  // If we decide to use BigInt
+  v8::MaybeLocal<v8::BigInt> v8_value = v8::BigInt::NewFromUnsigned(v8::Isolate::GetCurrent(), static_cast<uint64_t>(value));
+  value_helper<v8::BigInt>(v8_value);
+}
+
+void NodeValueWriter::write_float32(ACE_CDR::Float value)
+{
+  primitive_helper<ACE_CDR::Float, v8::Number>(value);
+}
+
+void NodeValueWriter::write_float64(ACE_CDR::Double value)
+{
+  primitive_helper<ACE_CDR::Double, v8::Number>(value);
+}
+
+void NodeValueWriter::write_float128(ACE_CDR::LongDouble value)
+{
+#if ACE_SIZEOF_LONG_DOUBLE == 16
+  primitive_helper<ACE_CDR::LongDouble, v8::Number>(value);
+#else
+  primitive_helper<ACE_CDR::LongDouble::NativeImpl, v8::Number>(value());
+#endif
+}
+
+void NodeValueWriter::write_fixed(const OpenDDS::FaceTypes::Fixed& /*value*/)
+{
+}
+
+void NodeValueWriter::write_char8(ACE_CDR::Char value)
+{
+  v8::MaybeLocal<v8::String> v8_value = Nan::New<v8::String>(&value, 1);
+  value_helper<v8::String>(v8_value);
+}
+
+void NodeValueWriter::write_char16(ACE_CDR::WChar value)
+{
+  const uint16_t c = static_cast<uint16_t>(value);
+  v8::MaybeLocal<v8::String> v8_value = Nan::New<v8::String>(&c, 1);
+  value_helper<v8::String>(v8_value);
+}
+
+void NodeValueWriter::write_string(const ACE_CDR::Char* value, size_t length)
+{
+  v8::MaybeLocal<v8::String> v8_value = Nan::New<v8::String>(value, length);
+  value_helper<v8::String>(v8_value);
+}
+
+void NodeValueWriter::write_wstring(const ACE_CDR::WChar* value, size_t length)
+{
+  uint16_t* const str = new uint16_t[length];
+  for (size_t i = 0; i < length; ++i) {
+    str[i] = static_cast<uint16_t>(value[i]);
+  }
+  v8::MaybeLocal<v8::String> v8_value = Nan::New<v8::String>(str, length);
+  value_helper<v8::String>(v8_value);
+  delete [] str;
+}
+
+void NodeValueWriter::write_enum(const char* name, ACE_CDR::Long value)
+{
+  ACE_UNUSED_ARG(value);
+  v8::MaybeLocal<v8::String> v8_value = Nan::New<v8::String>(name);
+  value_helper<v8::String>(v8_value);
+}
+
+} // NodeOpenDDS

--- a/src/NodeValueWriter.cpp
+++ b/src/NodeValueWriter.cpp
@@ -49,7 +49,10 @@ void NodeValueWriter::end_union()
 
 void NodeValueWriter::begin_discriminator()
 {
-  next_key_ = "$discriminator";
+  next_key_ = "_d";
+
+  // For whenever we switch to JSON spec compliance and/or have NodeValueReader up and running
+  //next_key_ = "$discriminator";
 }
 
 void NodeValueWriter::end_discriminator()
@@ -146,27 +149,27 @@ void NodeValueWriter::write_uint32(ACE_CDR::ULong value)
 void NodeValueWriter::write_int64(ACE_CDR::LongLong value)
 {
   // If we decide not to use BigInt
-  //char buff[21]; // 2^63 is 19 characters long in decimal representation, plus optional sign, plus null
-  //std::sprintf(buff, "%ld", value);
-  //v8::MaybeLocal<v8::String> v8_value = Nan::New<v8::String>(buff, std::strlen(buff));
-  //value_helper<v8::String>(v8_value);
+  char buff[21]; // 2^63 is 19 characters long in decimal representation, plus optional sign, plus null
+  std::sprintf(buff, "%ld", value);
+  v8::MaybeLocal<v8::String> v8_value = Nan::New<v8::String>(buff, std::strlen(buff));
+  value_helper<v8::String>(v8_value);
 
   // If we decide to use BigInt
-  v8::MaybeLocal<v8::BigInt> v8_value = v8::BigInt::New(v8::Isolate::GetCurrent(), static_cast<int64_t>(value));
-  value_helper<v8::BigInt>(v8_value);
+  //v8::MaybeLocal<v8::BigInt> v8_value = v8::BigInt::New(v8::Isolate::GetCurrent(), static_cast<int64_t>(value));
+  //value_helper<v8::BigInt>(v8_value);
 }
 
 void NodeValueWriter::write_uint64(ACE_CDR::ULongLong value)
 {
   // If we decide not to use BigInt
-  //char buff[21]; // 2^64 is 20 characters long in decimal representation, plus null
-  //std::sprintf(buff, "%lu", value);
-  //v8::MaybeLocal<v8::String> v8_value = Nan::New<v8::String>(buff, std::strlen(buff));
-  //value_helper<v8::String>(v8_value);
+  char buff[21]; // 2^64 is 20 characters long in decimal representation, plus null
+  std::sprintf(buff, "%lu", value);
+  v8::MaybeLocal<v8::String> v8_value = Nan::New<v8::String>(buff, std::strlen(buff));
+  value_helper<v8::String>(v8_value);
 
   // If we decide to use BigInt
-  v8::MaybeLocal<v8::BigInt> v8_value = v8::BigInt::NewFromUnsigned(v8::Isolate::GetCurrent(), static_cast<uint64_t>(value));
-  value_helper<v8::BigInt>(v8_value);
+  //v8::MaybeLocal<v8::BigInt> v8_value = v8::BigInt::NewFromUnsigned(v8::Isolate::GetCurrent(), static_cast<uint64_t>(value));
+  //value_helper<v8::BigInt>(v8_value);
 }
 
 void NodeValueWriter::write_float32(ACE_CDR::Float value)

--- a/src/NodeValueWriter.h
+++ b/src/NodeValueWriter.h
@@ -1,0 +1,124 @@
+#ifndef NODE_VALUE_WRITER_H
+#define NODE_VALUE_WRITER_H
+
+#if !defined (ACE_LACKS_PRAGMA_ONCE)
+#pragma once
+#endif /* ACE_LACKS_PRAGMA_ONCE */
+
+#include <dds/DCPS/ValueWriter.h>
+
+#include <nan.h>
+
+#include <sstream>
+
+namespace NodeOpenDDS {
+
+class NodeValueWriter : public OpenDDS::DCPS::ValueWriter {
+public:
+  NodeValueWriter();
+
+  void begin_struct();
+  void end_struct();
+  void begin_struct_member(const DDS::MemberDescriptor& descriptor);
+  void end_struct_member();
+
+  void begin_union();
+  void end_union();
+  void begin_discriminator();
+  void end_discriminator();
+  void begin_union_member(const char* name);
+  void end_union_member();
+
+  void begin_array();
+  void end_array();
+  void begin_sequence();
+  void end_sequence();
+  void begin_element(size_t idx);
+  void end_element();
+
+  void write_boolean(ACE_CDR::Boolean value);
+  void write_byte(ACE_CDR::Octet value);
+#if OPENDDS_HAS_EXPLICIT_INTS
+  void write_int8(ACE_CDR::Int8 value);
+  void write_uint8(ACE_CDR::UInt8 value);
+#endif
+  void write_int16(ACE_CDR::Short value);
+  void write_uint16(ACE_CDR::UShort value);
+  void write_int32(ACE_CDR::Long value);
+  void write_uint32(ACE_CDR::ULong value);
+  void write_int64(ACE_CDR::LongLong value);
+  void write_uint64(ACE_CDR::ULongLong value);
+  void write_float32(ACE_CDR::Float value);
+  void write_float64(ACE_CDR::Double value);
+  void write_float128(ACE_CDR::LongDouble value);
+  void write_fixed(const OpenDDS::FaceTypes::Fixed& value);
+  void write_char8(ACE_CDR::Char value);
+  void write_char16(ACE_CDR::WChar value);
+  void write_string(const ACE_CDR::Char* value, size_t length);
+  void write_wstring(const ACE_CDR::WChar* value, size_t length);
+  void write_enum(const char* name, ACE_CDR::Long value);
+
+  template <typename V>
+  void value_helper(v8::MaybeLocal<V>& v8_value)
+  {
+    if (v8_value.IsEmpty()) {
+      return;
+    }
+
+    if (object_stack_.empty()) {
+      return;
+    }
+
+    if (object_stack_.back()->IsArray()) {
+      uint32_t next_index = static_cast<uint32_t>(next_index_);
+      Nan::Set(object_stack_.back(), next_index, v8_value.ToLocalChecked());
+    } else {
+      v8::MaybeLocal<v8::String> key = Nan::New<v8::String>(next_key_.c_str());
+      if (!key.IsEmpty()) {
+        Nan::Set(object_stack_.back(), key.ToLocalChecked(), v8_value.ToLocalChecked());
+      }
+    }
+  }
+
+  template <typename T, typename V>
+  void primitive_helper(T value)
+  {
+    v8::MaybeLocal<V> v8_value = Nan::New<V>(value);
+    value_helper<V>(v8_value);
+  }
+
+  template <typename T>
+  void object_helper()
+  {
+    v8::MaybeLocal<v8::Object> temp = Nan::New<T>();
+    if (temp.IsEmpty()) {
+      return;
+    }
+
+    if (!object_stack_.empty()) {
+      if (object_stack_.back()->IsArray()) {
+        uint32_t next_index = static_cast<uint32_t>(next_index_);
+        Nan::Set(object_stack_.back(), next_index, temp.ToLocalChecked());
+      } else {
+        v8::MaybeLocal<v8::String> key = Nan::New<v8::String>(next_key_.c_str());
+        if (!key.IsEmpty()) {
+          Nan::Set(object_stack_.back(), key.ToLocalChecked(), temp.ToLocalChecked());
+        }
+      }
+    }
+    object_stack_.push_back(temp.ToLocalChecked());
+  }
+
+  v8::Local<v8::Object> get_result() { v8::Local<v8::Object> result = result_; result_.Clear(); return result; }
+
+private:
+
+  v8::Local<v8::Object> result_;
+  OPENDDS_VECTOR(v8::Local<v8::Object>) object_stack_;
+  std::string next_key_;
+  size_t next_index_;
+};
+
+} // NodeOpenDDS
+
+#endif  /* NODE_VALUE_WRITER_H */

--- a/src/node-opendds.cpp
+++ b/src/node-opendds.cpp
@@ -503,7 +503,7 @@ namespace {
     // TODO Handle non-infinite durations
 
 
-    ACE_DEBUG((LM_DEBUG, "(%P|%t) node_opendds::wait_for_acknowledgments() - calling dw's wait_for_acknowledgments %d\n", return_code));
+    ACE_DEBUG((LM_DEBUG, "(%P|%t) node_opendds::wait_for_acknowledgments() - calling dw's wait_for_acknowledgments\n"));
 
     const DDS::Duration_t delay = {DDS::DURATION_INFINITE_SEC, DDS::DURATION_INFINITE_NSEC};
     const DDS::ReturnCode_t return_code = dw->wait_for_acknowledgments(delay);

--- a/src/node-opendds.cpp
+++ b/src/node-opendds.cpp
@@ -138,6 +138,7 @@ namespace {
     part->delete_contained_entities();
     const DDS::DomainParticipantFactory_var dpf = TheParticipantFactory;
     dpf->delete_participant(part);
+    ACE_DEBUG((LM_DEBUG, "(%P|%t) node_opendds::delete_participant() - delete_participant returned successfully\n"));
     fci.GetReturnValue().SetUndefined();
   }
 
@@ -482,6 +483,9 @@ namespace {
 
     void* sample_vp = tc->fromV8(sample_obj);
     DDS::ReturnCode_t return_code = tc->write_helper(dw, sample_vp, handle);
+
+    ACE_DEBUG((LM_DEBUG, "(%P|%t) node_opendds::write() - dw's write returned %d\n", return_code));
+
     tc->deleteFromV8Result(sample_vp);
     if (return_code != DDS::RETCODE_OK) {
       Nan::ThrowError("couldn't write sample");
@@ -498,8 +502,13 @@ namespace {
 
     // TODO Handle non-infinite durations
 
+
+    ACE_DEBUG((LM_DEBUG, "(%P|%t) node_opendds::wait_for_acknowledgments() - calling dw's wait_for_acknowledgments %d\n", return_code));
+
     const DDS::Duration_t delay = {DDS::DURATION_INFINITE_SEC, DDS::DURATION_INFINITE_NSEC};
     const DDS::ReturnCode_t return_code = dw->wait_for_acknowledgments(delay);
+
+    ACE_DEBUG((LM_DEBUG, "(%P|%t) node_opendds::wait_for_acknowledgments() - dw's wait_for_acknowledgments returned %d\n", return_code));
 
     if (return_code != DDS::RETCODE_OK) {
       Nan::ThrowError("couldn't wait for acknowledgments");

--- a/src/node-opendds.cpp
+++ b/src/node-opendds.cpp
@@ -282,7 +282,7 @@ namespace {
       return;
     }
 
-    OpenDDS::DCPS::DataReaderImpl* dri= dynamic_cast<OpenDDS::DCPS::DataReaderImpl*>(dr.in());
+    OpenDDS::DCPS::DataReaderImpl* dri = dynamic_cast<OpenDDS::DCPS::DataReaderImpl*>(dr.in());
     if (dri) {
       ndrl->set_value_writer_dispatcher(dri->get_value_writer_dispatcher());
     }

--- a/src/node-opendds.cpp
+++ b/src/node-opendds.cpp
@@ -113,7 +113,6 @@ namespace {
     Nan::SetMethod(ot, "create_datawriter", create_datawriter);
     const Local<Object> obj = ot->NewInstance(Nan::GetCurrentContext()).ToLocalChecked();
     Nan::SetInternalFieldPointer(obj, 0, dp._retn());
-    ACE_DEBUG((LM_DEBUG, "(%P|%t) node-opendds::create_participant() - create_participant returned successfully\n"));
     fci.GetReturnValue().Set(obj);
   }
 
@@ -139,7 +138,6 @@ namespace {
     part->delete_contained_entities();
     const DDS::DomainParticipantFactory_var dpf = TheParticipantFactory;
     dpf->delete_participant(part);
-    ACE_DEBUG((LM_DEBUG, "(%P|%t) node-opendds::delete_participant() - delete_participant returned successfully\n"));
     fci.GetReturnValue().SetUndefined();
   }
 
@@ -294,7 +292,6 @@ namespace {
     const Local<Object> obj = ot->NewInstance(Nan::GetCurrentContext()).ToLocalChecked();
     Nan::SetInternalFieldPointer(obj, 0, dr._retn());
     ndrl->set_javascript_datareader(obj);
-    ACE_DEBUG((LM_DEBUG, "(%P|%t) node-opendds::subscribe() - subscribe returned successfully\n"));
     fci.GetReturnValue().Set(obj);
   }
 
@@ -420,7 +417,6 @@ namespace {
     const Local<Object> obj = ot->NewInstance(Nan::GetCurrentContext()).ToLocalChecked();
     Nan::SetInternalFieldPointer(obj, 0, dw._retn());
     Nan::SetInternalFieldPointer(obj, 1, const_cast<OpenDDS::DCPS::V8TypeConverter*>(tc));
-    ACE_DEBUG((LM_DEBUG, "(%P|%t) node-opendds::create_datawriter() - create_datawriter returned successfully\n"));
     fci.GetReturnValue().Set(obj);
   }
 
@@ -486,9 +482,6 @@ namespace {
 
     void* sample_vp = tc->fromV8(sample_obj);
     DDS::ReturnCode_t return_code = tc->write_helper(dw, sample_vp, handle);
-
-    ACE_DEBUG((LM_DEBUG, "(%P|%t) node-opendds::write() - dw's write returned %d\n", return_code));
-
     tc->deleteFromV8Result(sample_vp);
     if (return_code != DDS::RETCODE_OK) {
       Nan::ThrowError("couldn't write sample");
@@ -505,13 +498,8 @@ namespace {
 
     // TODO Handle non-infinite durations
 
-
-    ACE_DEBUG((LM_DEBUG, "(%P|%t) node-opendds::wait_for_acknowledgments() - calling dw's wait_for_acknowledgments\n"));
-
     const DDS::Duration_t delay = {DDS::DURATION_INFINITE_SEC, DDS::DURATION_INFINITE_NSEC};
     const DDS::ReturnCode_t return_code = dw->wait_for_acknowledgments(delay);
-
-    ACE_DEBUG((LM_DEBUG, "(%P|%t) node-opendds::wait_for_acknowledgments() - dw's wait_for_acknowledgments returned %d\n", return_code));
 
     if (return_code != DDS::RETCODE_OK) {
       Nan::ThrowError("couldn't wait for acknowledgments");

--- a/src/node-opendds.cpp
+++ b/src/node-opendds.cpp
@@ -254,7 +254,7 @@ namespace {
     }
 
     Local<Value> cb = fci[fci.Length() - 1];
-    NodeDRListener* const ndrl = new NodeDRListener(dp, cb.As<Function>(), *tc);
+    NodeDRListener* const ndrl = new NodeDRListener(dp, cb.As<Function>());
     const DDS::DataReaderListener_var listen(ndrl);
 
     DDS::DataReaderQos dr_qos;
@@ -280,6 +280,11 @@ namespace {
       Nan::ThrowError("couldn't create DataReader");
       fci.GetReturnValue().SetUndefined();
       return;
+    }
+
+    OpenDDS::DCPS::DataReaderImpl* dri= dynamic_cast<OpenDDS::DCPS::DataReaderImpl*>(dr.in());
+    if (dri) {
+      ndrl->set_value_writer_dispatcher(dri->get_value_writer_dispatcher());
     }
 
     const Local<ObjectTemplate> ot = Nan::New<ObjectTemplate>();

--- a/src/node-opendds.cpp
+++ b/src/node-opendds.cpp
@@ -642,4 +642,11 @@ namespace {
   }
 }
 
+#ifdef ACE_LINUX
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wcast-function-type"
+#endif
 NODE_MODULE(node_opendds, init_node_opendds);
+#ifdef ACE_LINUX
+#pragma GCC diagnostic pop
+#endif

--- a/src/node-opendds.cpp
+++ b/src/node-opendds.cpp
@@ -113,6 +113,7 @@ namespace {
     Nan::SetMethod(ot, "create_datawriter", create_datawriter);
     const Local<Object> obj = ot->NewInstance(Nan::GetCurrentContext()).ToLocalChecked();
     Nan::SetInternalFieldPointer(obj, 0, dp._retn());
+    ACE_DEBUG((LM_DEBUG, "(%P|%t) node-opendds::create_participant() - create_participant returned successfully\n"));
     fci.GetReturnValue().Set(obj);
   }
 
@@ -138,7 +139,7 @@ namespace {
     part->delete_contained_entities();
     const DDS::DomainParticipantFactory_var dpf = TheParticipantFactory;
     dpf->delete_participant(part);
-    ACE_DEBUG((LM_DEBUG, "(%P|%t) node_opendds::delete_participant() - delete_participant returned successfully\n"));
+    ACE_DEBUG((LM_DEBUG, "(%P|%t) node-opendds::delete_participant() - delete_participant returned successfully\n"));
     fci.GetReturnValue().SetUndefined();
   }
 
@@ -293,6 +294,7 @@ namespace {
     const Local<Object> obj = ot->NewInstance(Nan::GetCurrentContext()).ToLocalChecked();
     Nan::SetInternalFieldPointer(obj, 0, dr._retn());
     ndrl->set_javascript_datareader(obj);
+    ACE_DEBUG((LM_DEBUG, "(%P|%t) node-opendds::subscribe() - subscribe returned successfully\n"));
     fci.GetReturnValue().Set(obj);
   }
 
@@ -418,6 +420,7 @@ namespace {
     const Local<Object> obj = ot->NewInstance(Nan::GetCurrentContext()).ToLocalChecked();
     Nan::SetInternalFieldPointer(obj, 0, dw._retn());
     Nan::SetInternalFieldPointer(obj, 1, const_cast<OpenDDS::DCPS::V8TypeConverter*>(tc));
+    ACE_DEBUG((LM_DEBUG, "(%P|%t) node-opendds::create_datawriter() - create_datawriter returned successfully\n"));
     fci.GetReturnValue().Set(obj);
   }
 
@@ -484,7 +487,7 @@ namespace {
     void* sample_vp = tc->fromV8(sample_obj);
     DDS::ReturnCode_t return_code = tc->write_helper(dw, sample_vp, handle);
 
-    ACE_DEBUG((LM_DEBUG, "(%P|%t) node_opendds::write() - dw's write returned %d\n", return_code));
+    ACE_DEBUG((LM_DEBUG, "(%P|%t) node-opendds::write() - dw's write returned %d\n", return_code));
 
     tc->deleteFromV8Result(sample_vp);
     if (return_code != DDS::RETCODE_OK) {
@@ -503,12 +506,12 @@ namespace {
     // TODO Handle non-infinite durations
 
 
-    ACE_DEBUG((LM_DEBUG, "(%P|%t) node_opendds::wait_for_acknowledgments() - calling dw's wait_for_acknowledgments\n"));
+    ACE_DEBUG((LM_DEBUG, "(%P|%t) node-opendds::wait_for_acknowledgments() - calling dw's wait_for_acknowledgments\n"));
 
     const DDS::Duration_t delay = {DDS::DURATION_INFINITE_SEC, DDS::DURATION_INFINITE_NSEC};
     const DDS::ReturnCode_t return_code = dw->wait_for_acknowledgments(delay);
 
-    ACE_DEBUG((LM_DEBUG, "(%P|%t) node_opendds::wait_for_acknowledgments() - dw's wait_for_acknowledgments returned %d\n", return_code));
+    ACE_DEBUG((LM_DEBUG, "(%P|%t) node-opendds::wait_for_acknowledgments() - dw's wait_for_acknowledgments returned %d\n", return_code));
 
     if (return_code != DDS::RETCODE_OK) {
       Nan::ThrowError("couldn't wait for acknowledgments");

--- a/test/run_test.pl
+++ b/test/run_test.pl
@@ -17,7 +17,7 @@ print "\nTest: @ARGV\n";
 
 my %args = map { $_ => 1 } @ARGV;
 my $secure = exists($args{"--secure"});
-my $rtps = exists($args{"--rtps"});
+my $rtps = $secure || exists($args{"--rtps"});
 
 my $scenario = "cpp2node";
 my $pub_node = 0;
@@ -36,7 +36,7 @@ if (exists($args{"node2cpp"})) {
   $sub_node = 0;
 }
 
-$test->setup_discovery("-ORBDebugLevel 1 -ORBLogFile DCPSInfoRepo.log") unless $secure || $rtps;
+$test->setup_discovery("-ORBDebugLevel 1 -ORBLogFile DCPSInfoRepo.log") unless $rtps;
 
 sub which {
   my $file = shift;
@@ -64,41 +64,30 @@ my $sub_args = "";
 if ($sub_node) {
   $sub_exec_name .= which("node");
   $sub_args .= "test_subscriber.js";
-  if ($secure) {
-    $sub_args .= " --secure";
-  } elsif ($rtps) {
-    $sub_args .= " --rtps";
-  }
 } else {
   $sub_exec_name .= "test_subscriber";
-  if ($secure) {
-    $sub_args .= " --secure -DCPSConfigFile rtps_disc.ini";
-  } elsif ($rtps) {
-    $sub_args .= " -DCPSConfigFile rtps_disc.ini";
-  }
 }
-
-$test->process("sub", $sub_exec_name, $sub_args);
 
 my $pub_exec_name = "";
 my $pub_args = "";
 if ($pub_node) {
   $pub_exec_name .= which("node");
   $pub_args .= "test_publisher.js";
-  if ($secure) {
-    $pub_args .= " --secure";
-  } elsif ($rtps) {
-    $pub_args .= " --rtps";
-  }
 } else {
   $pub_exec_name .= "test_publisher";
-  if ($secure) {
-    $pub_args .= " --secure -DCPSConfigFile rtps_disc.ini";
-  } elsif ($rtps) {
-    $pub_args .= " -DCPSConfigFile rtps_disc.ini";
-  }
 }
 
+if ($secure) {
+  $pub_args .= " --secure";
+  $sub_args .= " --secure";
+}
+
+if ($rtps) {
+  $pub_args .= " -DCPSConfigFile rtps_disc.ini";
+  $sub_args .= " -DCPSConfigFile rtps_disc.ini";
+}
+
+$test->process("sub", $sub_exec_name, $sub_args);
 $test->process("pub", $pub_exec_name, $pub_args);
 
 $test->start_process("sub");

--- a/test/run_test.pl
+++ b/test/run_test.pl
@@ -34,7 +34,7 @@ if (exists($args{"node2cpp"})) {
   $sub_node = 0;
 }
 
-$test->setup_discovery("-ORBVerboseLogging 1 -ORBDebugLevel 1 -ORBLogFile DCPSInfoRepo.log") unless $rtps;
+$test->setup_discovery("-ORBDebugLevel 1 -ORBLogFile DCPSInfoRepo.log") unless $rtps;
 
 sub which {
   my $file = shift;

--- a/test/run_test.pl
+++ b/test/run_test.pl
@@ -78,7 +78,7 @@ if ($pub_node) {
 }
 
 $pub_args .= " -ORBVerboseLogging 1 -DCPSDebugLevel 5 -DCPSTransportDebugLevel 5";
-$sub_args .= " -DCPSDebugLevel 5 -DCPSTransportDebugLevel 5";
+$sub_args .= " -ORBVerboseLogging 1 -DCPSDebugLevel 5 -DCPSTransportDebugLevel 5";
 
 if ($secure) {
   $pub_args .= " --secure";

--- a/test/run_test.pl
+++ b/test/run_test.pl
@@ -77,8 +77,8 @@ if ($pub_node) {
   $pub_exec_name .= "test_publisher";
 }
 
-$pub_args .= " -DCPSDebugLevel 5";
-$sub_args .= " -DCPSDebugLevel 5";
+$pub_args .= " -DCPSDebugLevel 5 -DCPSTransportDebugLevel 5";
+$sub_args .= " -DCPSDebugLevel 5 -DCPSTransportDebugLevel 5";
 
 if ($secure) {
   $pub_args .= " --secure";

--- a/test/run_test.pl
+++ b/test/run_test.pl
@@ -36,7 +36,7 @@ if (exists($args{"node2cpp"})) {
   $sub_node = 0;
 }
 
-$test->setup_discovery("-ORBDebugLevel 1 -ORBLogFile DCPSInfoRepo.log") unless $rtps;
+$test->setup_discovery("-ORBVerboseLogging 1 -ORBDebugLevel 1 -ORBLogFile DCPSInfoRepo.log") unless $rtps;
 
 sub which {
   my $file = shift;
@@ -77,7 +77,7 @@ if ($pub_node) {
   $pub_exec_name .= "test_publisher";
 }
 
-$pub_args .= " -DCPSDebugLevel 5 -DCPSTransportDebugLevel 5";
+$pub_args .= " -ORBVerboseLogging 1 -DCPSDebugLevel 5 -DCPSTransportDebugLevel 5";
 $sub_args .= " -DCPSDebugLevel 5 -DCPSTransportDebugLevel 5";
 
 if ($secure) {

--- a/test/run_test.pl
+++ b/test/run_test.pl
@@ -9,8 +9,6 @@ use lib "$ACE_ROOT/bin";
 use PerlDDS::Run_Test;
 use strict;
 
-my $status = 0;
-
 my $test = new PerlDDS::TestFramework();
 
 print "\nTest: @ARGV\n";
@@ -96,6 +94,4 @@ $test->process("pub", $pub_exec_name, $pub_args);
 $test->start_process("sub");
 $test->start_process("pub");
 
-exit $test->finish(30);
-
-exit $status;
+exit $test->finish(60);

--- a/test/run_test.pl
+++ b/test/run_test.pl
@@ -77,6 +77,9 @@ if ($pub_node) {
   $pub_exec_name .= "test_publisher";
 }
 
+$pub_args .= " -DCPSDebugLevel 5";
+$sub_args .= " -DCPSDebugLevel 5";
+
 if ($secure) {
   $pub_args .= " --secure";
   $sub_args .= " --secure";

--- a/test/test_publisher.js
+++ b/test/test_publisher.js
@@ -5,7 +5,6 @@ var ddsCerts = process.env.DDS_ROOT + "/tests/security/certs/identity";
 
 var qos = {user_data: 'foo'};
 var secure = process.argv.includes('--secure');
-var rtps = process.argv.includes('--rtps');
 if (secure) {
   qos.property = { value: [
 
@@ -31,11 +30,7 @@ if (secure) {
 }
 
 function init_opendds(opendds_addon) {
-  if (secure || rtps) {
-    return opendds_addon.initialize('-DCPSConfigFile', 'rtps_disc.ini');
-  } else {
-    return opendds_addon.initialize();
-  }
+  return opendds_addon.initialize(process.argv.slice(2));
 }
 
 var opendds_addon = require('../lib/node-opendds'),

--- a/test/test_publisher.js
+++ b/test/test_publisher.js
@@ -113,7 +113,7 @@ try {
     }
   });
 
-  setTimeout(function () { doStuff(writer); }, 3000);
+  setTimeout(function () { doStuff(writer); }, 10000);
 
 } catch (e) {
   console.log(e);

--- a/test/test_publisher.js
+++ b/test/test_publisher.js
@@ -30,7 +30,7 @@ if (secure) {
 }
 
 function init_opendds(opendds_addon) {
-  return opendds_addon.initialize(process.argv.slice(2));
+  return opendds_addon.initialize(... process.argv.slice(2));
 }
 
 var opendds_addon = require('../lib/node-opendds'),

--- a/test/test_subscriber.cpp
+++ b/test/test_subscriber.cpp
@@ -388,7 +388,7 @@ int ACE_TMAIN(int argc, ACE_TCHAR* argv[])
     dpf->delete_participant(participant);
     TheServiceParticipant->shutdown();
 
-    std::cout << "Success!" << std::endl;
+    std::cout << "Success!\n" << std::flush;
 
   } catch (...) {
     std::cerr << "ERROR!\n";

--- a/test/test_subscriber.js
+++ b/test/test_subscriber.js
@@ -5,7 +5,6 @@ var ddsCerts = process.env.DDS_ROOT + "/tests/security/certs/identity";
 
 var qos = {user_data: 'foo'};
 var secure = process.argv.includes('--secure');
-var rtps = process.argv.includes('--rtps');
 if (secure) {
   qos.property = { value: [
 
@@ -31,11 +30,7 @@ if (secure) {
 }
 
 function init_opendds(opendds_addon) {
-  if (secure || rtps) {
-    return opendds_addon.initialize('-DCPSConfigFile', 'rtps_disc.ini');
-  } else {
-    return opendds_addon.initialize();
-  }
+  return opendds_addon.initialize(process.argv.slice(2));
 }
 
 var opendds_addon = require('../lib/node-opendds'),

--- a/test/test_subscriber.js
+++ b/test/test_subscriber.js
@@ -155,7 +155,7 @@ try {
           process.exitCode = 1;
         }
         if (sample.id == last_sample_id) {
-          setTimeout(function () { doStuff(participant, dr); }, 3000);
+          setTimeout(function () { doStuff(participant, dr); }, 10000);
         }
       }
     } catch (e) {

--- a/test/test_subscriber.js
+++ b/test/test_subscriber.js
@@ -30,7 +30,7 @@ if (secure) {
 }
 
 function init_opendds(opendds_addon) {
-  return opendds_addon.initialize(process.argv.slice(2));
+  return opendds_addon.initialize(... process.argv.slice(2));
 }
 
 var opendds_addon = require('../lib/node-opendds'),

--- a/test/test_subscriber.js
+++ b/test/test_subscriber.js
@@ -48,7 +48,7 @@ var opendds_addon = require('../lib/node-opendds'),
   infinite = {sec: dds_inf, nanosec: dds_inf};
 
 function log(label, object) {
-  console.log(label + ': ' + JSON.stringify(object, null, 2));
+  console.log(label + ': ' + JSON.stringify(object, (key, value) => typeof value === 'bigint' ? value.toString() : value, 2));
 }
 
 function doStuff(participant, reader) {
@@ -154,8 +154,8 @@ try {
             sample.sa[1] != "east" ||
             sample.sa[2] != "south" ||
             sample.sa[3] != "west" ||
-            (sample.id == 23 && (sample.mu._d != "one" || sample.mu.a != 6)) ||
-            (sample.id == 24 && (sample.mu._d != "four" || sample.mu.s.length != 2 || sample.mu.s[0].length != 4 || sample.mu.s[1].length != 1))) {
+            (sample.id == 23 && (sample.mu.$discriminator != "one" || sample.mu.a != 6)) ||
+            (sample.id == 24 && (sample.mu.$discriminator != "four" || sample.mu.s.length != 2 || sample.mu.s[0].length != 4 || sample.mu.s[1].length != 1))) {
           console.log("Error in data!");
           process.exitCode = 1;
         }

--- a/test/test_subscriber.js
+++ b/test/test_subscriber.js
@@ -154,8 +154,8 @@ try {
             sample.sa[1] != "east" ||
             sample.sa[2] != "south" ||
             sample.sa[3] != "west" ||
-            (sample.id == 23 && (sample.mu.$discriminator != "one" || sample.mu.a != 6)) ||
-            (sample.id == 24 && (sample.mu.$discriminator != "four" || sample.mu.s.length != 2 || sample.mu.s[0].length != 4 || sample.mu.s[1].length != 1))) {
+            (sample.id == 23 && (sample.mu._d != "one" || sample.mu.a != 6)) ||
+            (sample.id == 24 && (sample.mu._d != "four" || sample.mu.s.length != 2 || sample.mu.s[0].length != 4 || sample.mu.s[1].length != 1))) {
           console.log("Error in data!");
           process.exitCode = 1;
         }


### PR DESCRIPTION
Problem: Node.js on windows hard-codes part of the standard library, causing potential compatibility issues for plugins using the same functions.

Solutions: Don't use those functions, but also make use of the new ValueWriter interfaces to have all "tov8" style NaN / V8 code inside the node-opendds addon directly, rather than using generated NaN/V8 TypeSupport library code. Eventually, we will want to do the same thing on the reader side as well.