### PR TITLE
Always attempt sample write to get non-valid sample info

### DIFF
--- a/src/NodeDRListener.cpp
+++ b/src/NodeDRListener.cpp
@@ -124,14 +124,14 @@ void NodeDRListener::push_back(const DDS::SampleInfo& src, const void* sample)
     return;
   }
 
-  if (src.valid_data && vd_) {
+  if (vd_) {
     vd_->write(nvw_, sample);
   }
 
   Local<Value> argv[] = {
     Nan::New(js_dr_),
     copyToV8(src),
-    (src.valid_data && vd_) ? nvw_.get_result().As<Value>() : Nan::Undefined().As<Value>()
+    vd_ ? nvw_.get_result().As<Value>() : Nan::Undefined().As<Value>()
   };
 
   Local<Function> callback = Nan::New(callback_);


### PR DESCRIPTION
Problem: For non-valid sample data (instance registration, unregister, dispose) the sample is undefined.

Solution: We always need to try to attempt writing with NodeValueWriter, even if we know some of the data will be bogus so that we can return key values.