### PR TITLE
Handle invalid-data reader callbacks

### DIFF
--- a/src/NodeDRListener.cpp
+++ b/src/NodeDRListener.cpp
@@ -129,7 +129,7 @@ void NodeDRListener::push_back(const DDS::SampleInfo& src, const void* sample)
   const OpenDDS::DCPS::Sample::Extent ext =
     src.valid_data ? OpenDDS::DCPS::Sample::Full : OpenDDS::DCPS::Sample::KeyOnly;
 
-  if (vd_) {
+  if (vd_ && src.valid_data) {
     if (!vd_->write(nvw_, sample, ext)) {
       ACE_ERROR((LM_WARNING, "WARNING: ValueDispatcher write failed\n"));
       return;
@@ -139,7 +139,7 @@ void NodeDRListener::push_back(const DDS::SampleInfo& src, const void* sample)
   Local<Value> argv[] = {
     Nan::New(js_dr_),
     copyToV8(src),
-    vd_ ? nvw_.get_result().As<Value>() : Nan::Undefined().As<Value>()
+    vd_ && src.valid_data ? nvw_.get_result().As<Value>() : Nan::Undefined().As<Value>()
   };
 
   Local<Function> callback = Nan::New(callback_);

--- a/test/test_subscriber.js
+++ b/test/test_subscriber.js
@@ -167,6 +167,9 @@ try {
         if (sample.id == last_sample_id) {
           setTimeout(function () { doStuff(participant, dr); }, 10000);
         }
+      } else if (sample !== undefined) {
+        console.log("Error: invalid-data callback included a sample payload");
+        process.exitCode = 1;
       }
     } catch (e) {
       console.log("Error in callback: " + e);


### PR DESCRIPTION
## Summary
- Avoid marshaling DDS samples into JavaScript when `SampleInfo.valid_data` is false.
- Pass `undefined` as the callback sample argument for invalid-data callbacks.
- Add a subscriber regression assertion for dispose/unregister callbacks that carry metadata without valid sample data.

## Rationale
DDS readers can receive callbacks where `valid_data` is false, such as instance lifecycle notifications from dispose/unregister. In those cases there is no full sample payload to marshal. The previous code still called `ValueDispatcher::write` for these callbacks, which can expose invalid or partial native sample data to JavaScript.

The callback already includes `SampleInfo`, so callers can inspect invalid-data notifications without receiving a misleading sample object.

## Testing
- `npm install`
- `mwc.pl -type gnuace && make`
- `./run_test.pl node2node`